### PR TITLE
Return the source organization id in lookup by package id

### DIFF
--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -953,7 +953,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/FileTreePage"
+                  $ref: "#/components/schemas/FileTreeWithOrgPage"
         "404":
           description: resource not found
           content:
@@ -1332,6 +1332,23 @@ components:
               type: array
               items:
                 $ref: "#/components/schemas/FileTreeNodeDTO"
+
+    FileTreeWithOrgPage:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/GenericResponsePage"
+        - type: object
+          required:
+            - organizationId
+            - files
+          properties:
+            files:
+              type: array
+              items:
+                $ref: "#/components/schemas/FileTreeNodeDTO"
+            organizationId:
+              type: integer
+
 
     FileTreeNodeDTO:
       description: >

--- a/server/src/main/scala/com/blackfynn/discover/handlers/FileHandler.scala
+++ b/server/src/main/scala/com/blackfynn/discover/handlers/FileHandler.scala
@@ -11,14 +11,16 @@ import com.pennsieve.discover.server.file.{
   FileHandler => GuardrailHandler,
   FileResource => GuardrailResource
 }
-
 import com.pennsieve.discover.db.PublicFilesMapper
 import com.pennsieve.discover.logging.{
   logRequestAndResponse,
   DiscoverLogContext
 }
 import com.pennsieve.discover.models.{ FileTreeNode, FileTreeNodeDTO }
-import com.pennsieve.discover.server.definitions.FileTreePage
+import com.pennsieve.discover.server.definitions.{
+  FileTreePage,
+  FileTreeWithOrgPage
+}
 
 /**
   * Handler for public endpoints for getting files from their sourcePackageId
@@ -56,16 +58,17 @@ class FileHandler(
     ports.db
       .run(query)
       .map {
-        case (total, Nil) =>
+        case (total, _, Nil) =>
           GuardrailResource.getFileFromSourcePackageIdResponse
             .NotFound(sourcePackageId)
-        case (total, files) =>
+        case (total, Some(organizationId), files) =>
           GuardrailResource.getFileFromSourcePackageIdResponse
             .OK(
-              FileTreePage(
+              FileTreeWithOrgPage(
                 totalCount = total,
                 limit = limit.getOrElse(defaultFileLimit),
                 offset = offset.getOrElse(defaultFileOffset),
+                organizationId = organizationId,
                 files = files.map { f =>
                   FileTreeNodeDTO(FileTreeNode(f))
                 }.toIndexedSeq

--- a/server/src/test/scala/com/blackfynn/discover/handlers/FileHandlerSpec.scala
+++ b/server/src/test/scala/com/blackfynn/discover/handlers/FileHandlerSpec.scala
@@ -37,7 +37,9 @@ class FileHandlerSpec
   "GET /files/{sourcePackageId}" should {
 
     "return the files of the latest version of a dataset when a valid sourcePackageId is passed" in {
+      val expectedOrgId = 3
       val v1 = TestUtilities.createDatasetV1(ports.db)(
+        sourceOrganizationId = expectedOrgId,
         status = PublishStatus.PublishSucceeded
       )
 
@@ -71,10 +73,11 @@ class FileHandlerSpec
         .getFileFromSourcePackageId("N:package:1")
         .awaitFinite()
 
-      val expected = client.definitions.FileTreePage(
+      val expected = client.definitions.FileTreeWithOrgPage(
         totalCount = 2,
         limit = 100,
         offset = 0,
+        organizationId = expectedOrgId,
         files = IndexedSeq(
           client.definitions.File(
             name = f1.name,
@@ -105,7 +108,9 @@ class FileHandlerSpec
     }
 
     "respect limit and offset and return the files of the latest version of a dataset when a valid sourcePackageId is passed" in {
+      val expectedOrgId = 4
       val v1 = TestUtilities.createDatasetV1(ports.db)(
+        sourceOrganizationId = expectedOrgId,
         status = PublishStatus.PublishSucceeded
       )
 
@@ -138,10 +143,11 @@ class FileHandlerSpec
         )
         .awaitFinite()
 
-      val expected = client.definitions.FileTreePage(
+      val expected = client.definitions.FileTreeWithOrgPage(
         totalCount = 3,
         limit = 2,
         offset = 1,
+        organizationId = expectedOrgId,
         files = IndexedSeq(
           client.definitions.File(
             name = f2.name,


### PR DESCRIPTION
This change adds the source organization id to the response of the already existing `discover/packages/{sourcePackageId}/files` endpoint. It assumes that all files in a package have the same source organization.
