### PR TITLE
Fix Akka dependency confict

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,9 +38,9 @@ lazy val headerLicenseValue = Some(
 )
 lazy val headerMappingsValue = HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment
 
-lazy val akkaHttpVersion = "10.1.11"
-lazy val akkaVersion = "2.6.5"
-lazy val alpakkaVersion = "1.1.0"
+lazy val akkaHttpVersion = "10.2.7"
+lazy val akkaVersion = "2.6.8"
+lazy val alpakkaVersion = "2.0.2"
 lazy val circeVersion = SettingKey[String]("circeVersion")
 lazy val circe212Version = "0.11.1"
 lazy val circe213Version = "0.14.1"

--- a/build.sbt
+++ b/build.sbt
@@ -38,12 +38,21 @@ lazy val headerLicenseValue = Some(
 )
 lazy val headerMappingsValue = HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment
 
-lazy val akkaHttpVersion = "10.2.7"
-lazy val akkaVersion = "2.6.8"
-lazy val alpakkaVersion = "2.0.2"
+lazy val akkaHttpVersion = SettingKey[String]("akkaHttpVersion")
+lazy val akkaVersion = SettingKey[String]("akkaVersion")
+lazy val alpakkaVersion = SettingKey[String]("alpakkaVersion")
+
+lazy val akkaHttp213Version = "10.2.7"
+lazy val akka213Version = "2.6.8"
+lazy val alpakka213Version = "2.0.2"
+lazy val akkaHttp212Version = "10.1.11"
+lazy val akka212Version = "2.6.5"
+lazy val alpakka212Version = "1.1.0"
+
 lazy val circeVersion = SettingKey[String]("circeVersion")
 lazy val circe212Version = "0.11.1"
 lazy val circe213Version = "0.14.1"
+
 lazy val coreVersion = "166-27f7fae"
 lazy val authMiddlewareVersion = "5.1.3"
 lazy val serviceUtilitiesVersion = "8-9751ee3"
@@ -89,12 +98,27 @@ lazy val server = project
       circe212Version,
       circe213Version
     ),
+    akkaVersion := getVersion(
+      scalaVersion.value,
+      akka212Version,
+      akka213Version
+    ),
+    akkaHttpVersion := getVersion(
+      scalaVersion.value,
+      akkaHttp212Version,
+      akkaHttp213Version
+    ),
+    alpakkaVersion := getVersion(
+      scalaVersion.value,
+      alpakka212Version,
+      alpakka213Version
+    ),
     /*dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
     ),*/
-    libraryDependencies ++= Seq(
+      libraryDependencies ++= Seq (
       "com.pennsieve" %% "service-utilities" % serviceUtilitiesVersion,
       "com.pennsieve" %% "utilities" % utilitiesVersion,
       "com.pennsieve" %% "auth-middleware" % authMiddlewareVersion,
@@ -104,15 +128,15 @@ lazy val server = project
       "io.circe" %% "circe-core" % circeVersion.value,
       "io.circe" %% "circe-generic" % circeVersion.value,
       "commons-io" % "commons-io" % "2.6",
-      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
-      "com.typesafe.akka" %% "akka-http-xml" % akkaHttpVersion,
-      "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-      "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
-      "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-      "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % alpakkaVersion,
-      "com.lightbend.akka" %% "akka-stream-alpakka-s3" % alpakkaVersion,
-      "com.lightbend.akka" %% "akka-stream-alpakka-awslambda" % alpakkaVersion,
-      "com.lightbend.akka" %% "akka-stream-alpakka-csv" % alpakkaVersion,
+      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion.value,
+      "com.typesafe.akka" %% "akka-http-xml" % akkaHttpVersion.value,
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion.value,
+      "com.typesafe.akka" %% "akka-slf4j" % akkaVersion.value,
+      "com.typesafe.akka" %% "akka-actor" % akkaVersion.value,
+      "com.lightbend.akka" %% "akka-stream-alpakka-sqs" % alpakkaVersion.value,
+      "com.lightbend.akka" %% "akka-stream-alpakka-s3" % alpakkaVersion.value,
+      "com.lightbend.akka" %% "akka-stream-alpakka-awslambda" % alpakkaVersion.value,
+      "com.lightbend.akka" %% "akka-stream-alpakka-csv" % alpakkaVersion.value,
       "software.amazon.awssdk" % "lambda" % awsSdkVersion,
       "software.amazon.awssdk" % "sfn" % awsSdkVersion,
       "software.amazon.awssdk" % "sns" % awsSdkVersion,
@@ -143,9 +167,9 @@ lazy val server = project
       "com.whisk" %% "docker-testkit-impl-spotify" % dockerItVersion % Test,
       "com.pennsieve" %% "utilities" % utilitiesVersion % "test" classifier "tests",
       "com.pennsieve" %% "service-utilities" % serviceUtilitiesVersion % "test" classifier "tests",
-      "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
-      "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
-      "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
+      "com.typesafe.akka" %% "akka-testkit" % akkaVersion.value % Test,
+      "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion.value % Test,
+      "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion.value % Test,
       "org.apache.httpcomponents" % "httpclient" % "4.5.8" % Test,
       "software.amazon.awssdk" % "s3" % awsSdkVersion % Test,
       "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % Test
@@ -330,15 +354,25 @@ lazy val client = project
       circe212Version,
       circe213Version
     ),
+    akkaVersion := getVersion(
+      scalaVersion.value,
+      akka212Version,
+      akka213Version
+    ),
+    akkaHttpVersion := getVersion(
+      scalaVersion.value,
+      akkaHttp212Version,
+      akkaHttp213Version
+    ),
     libraryDependencies ++= Seq(
       "com.pennsieve" %% "core-models" % coreVersion,
       "io.circe" %% "circe-core" % circeVersion.value,
       "io.circe" %% "circe-generic" % circeVersion.value,
       "io.circe" %% "circe-jawn" % circeVersion.value,
-      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
-      "com.typesafe.akka" %% "akka-actor" % akkaVersion,
-      "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-      "com.typesafe.akka" %% "akka-slf4j" % akkaVersion
+      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion.value,
+      "com.typesafe.akka" %% "akka-actor" % akkaVersion.value,
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion.value,
+      "com.typesafe.akka" %% "akka-slf4j" % akkaVersion.value
     ),
     libraryDependencies ++= handle212OnlyDependency(
       scalaVersion.value,
@@ -394,12 +428,22 @@ lazy val scripts = project
       circe212Version,
       circe213Version
     ),
+    akkaVersion := getVersion(
+      scalaVersion.value,
+      akka212Version,
+      akka213Version
+    ),
+    akkaHttpVersion := getVersion(
+      scalaVersion.value,
+      akkaHttp212Version,
+      akkaHttp213Version
+    ),
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion.value,
       "io.circe" %% "circe-generic" % circeVersion.value,
       "io.circe" %% "circe-jawn" % circeVersion.value,
-      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion,
-      "com.typesafe.akka" %% "akka-stream" % akkaVersion,
+      "com.typesafe.akka" %% "akka-http" % akkaHttpVersion.value,
+      "com.typesafe.akka" %% "akka-stream" % akkaVersion.value,
       "com.pennsieve" %% "service-utilities" % serviceUtilitiesVersion
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -61,20 +61,6 @@ lazy val jacksonVersion = "2.9.6"
 
 lazy val Integration = config("integration") extend (Test)
 
-lazy val serverTestDependencies = Seq(
-  "org.scalatest" %% "scalatest" % "3.2.12" % Test,
-  "com.whisk" %% "docker-testkit-scalatest" % dockerItVersion % Test,
-  "com.whisk" %% "docker-testkit-impl-spotify" % dockerItVersion % Test,
-  "com.pennsieve" %% "utilities" % utilitiesVersion % "test" classifier "tests",
-  "com.pennsieve" %% "service-utilities" % serviceUtilitiesVersion % "test" classifier "tests",
-  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
-  "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
-  "org.apache.httpcomponents" % "httpclient" % "4.5.8" % Test,
-  "software.amazon.awssdk" % "s3" % awsSdkVersion % Test,
-  "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % Test
-)
-
 lazy val server = project
   .dependsOn(client % "test")
   .enablePlugins(AutomateHeaderPlugin)
@@ -150,9 +136,9 @@ lazy val server = project
       "org.apache.commons" % "commons-lang3" % "3.9",
       "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
       "org.scalikejdbc" %% "scalikejdbc" % "3.4.0",
-      "com.zaneli" %% "scalikejdbc-athena" % "0.2.4"
+      "com.zaneli" %% "scalikejdbc-athena" % "0.2.4",
       // Test dependencies
-      /*"org.scalatest" %% "scalatest" % "3.2.12" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.12" % Test,
       "com.whisk" %% "docker-testkit-scalatest" % dockerItVersion % Test,
       "com.whisk" %% "docker-testkit-impl-spotify" % dockerItVersion % Test,
       "com.pennsieve" %% "utilities" % utilitiesVersion % "test" classifier "tests",
@@ -162,8 +148,8 @@ lazy val server = project
       "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % Test,
       "org.apache.httpcomponents" % "httpclient" % "4.5.8" % Test,
       "software.amazon.awssdk" % "s3" % awsSdkVersion % Test,
-      "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % Test*/
-    ) ++ serverTestDependencies,
+      "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % Test
+    ),
     Compile / guardrailTasks := List(
       ScalaServer(
         file("openapi/discover-service.yml"),
@@ -254,36 +240,6 @@ lazy val server = project
     coverageMinimumStmtTotal := 70,
     coverageFailOnMinimum := true
   )
-
-lazy val createFatJarTest =
-  taskKey[Unit]("Writes a bash script to run tests against fat jar")
-
-lazy val fatJarTest = project.settings(
-  name := "discover-service-fat-jar-test",
-  libraryDependencies ++= serverTestDependencies,
-  createFatJarTest := {
-    import java.io.File
-    val script: File = new File("target/fatJarTest.sh")
-    val fatJar: File = (server / assembly).value
-    val serverTestDependenciesJars: Seq[File] =
-      (Test / dependencyClasspath).value.map(_.data)
-    // server has a test-only dependency on client, so client is not in fat jar but we need them
-    val clientClassDirectory: File = (client / Compile / classDirectory).value
-    val classpath =
-      (Seq(fatJar, clientClassDirectory) ++ serverTestDependenciesJars)
-        .mkString(File.pathSeparator)
-    val testDirectory = (server / Test / classDirectory).value.toString
-      .replace(" ", "\\ ")
-    sbt.IO.writeLines(
-      script,
-      Seq(
-        s"""classpath="$classpath"""",
-        s"""scala -cp "$$classpath" org.scalatest.tools.Runner -R "$testDirectory" -oI"""
-      )
-    )
-
-  }
-)
 
 lazy val syncElasticSearch = project
   .enablePlugins(AutomateHeaderPlugin)

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -116,6 +116,7 @@ alpakka.s3 {
       default-region = ${?REGION}
     }
   }
+  access-style = path
 }
 
 akka {

--- a/server/src/main/scala/com/pennsieve/discover/Server.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Server.scala
@@ -94,7 +94,7 @@ object Server extends App with StrictLogging {
 
   val routes: Route = Route.seal(createRoutes(ports))
 
-  Http().bindAndHandle(routes, config.host, config.port)
+  Http().newServerAt(config.host, config.port).bind(routes)
   logger.info(s"Server online at http://${config.host}:${config.port}")
 
   Await.result(system.whenTerminated, Duration.Inf)

--- a/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
@@ -79,6 +79,7 @@ class S3StreamClientSpec
       "alpakka.s3.aws.credentials.secret-access-key",
       ConfigValueFactory.fromAnyRef(secretKey)
     )
+    .withValue("alpakka.s3.access-style", ConfigValueFactory.fromAnyRef("path"))
 
   implicit lazy private val system: ActorSystem =
     ActorSystem("discover-service", config)

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -105,7 +105,7 @@ class DatasetHandlerSpec
     Route.seal(DatasetHandler.routes(ports))
 
   def createClient(routes: Route): DatasetClient =
-    DatasetClient.httpClient(Route.asyncHandler(routes))
+    DatasetClient.httpClient(Route.toFunction(routes))
 
   def toClientDefinition(
     dto: server.definitions.PublicDatasetDto

--- a/server/src/test/scala/com/pennsieve/discover/handlers/FileHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/FileHandlerSpec.scala
@@ -31,7 +31,7 @@ class FileHandlerSpec
     Route.seal(FileHandler.routes(ports))
 
   def createClient(routes: Route): FileClient =
-    FileClient.httpClient(Route.asyncHandler(routes))
+    FileClient.httpClient(Route.toFunction(routes))
 
   val fileClient: FileClient = createClient(createRoutes())
 

--- a/server/src/test/scala/com/pennsieve/discover/handlers/MetricsHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/MetricsHandlerSpec.scala
@@ -26,7 +26,7 @@ class MetricsHandlerSpec
     Route.seal(MetricsHandler.routes(ports))
 
   def createClient(routes: Route): MetricsClient =
-    MetricsClient.httpClient(Route.asyncHandler(routes))
+    MetricsClient.httpClient(Route.toFunction(routes))
 
   val metricsClient: MetricsClient = createClient(createRoutes())
 

--- a/server/src/test/scala/com/pennsieve/discover/handlers/OrganizationHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/OrganizationHandlerSpec.scala
@@ -33,7 +33,7 @@ class OrganizationHandlerSpec
     Route.seal(OrganizationHandler.routes(ports))
 
   def createClient(routes: Route): OrganizationClient =
-    OrganizationClient.httpClient(Route.asyncHandler(routes))
+    OrganizationClient.httpClient(Route.toFunction(routes))
 
   val organizationClient: OrganizationClient = createClient(createRoutes())
 

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -58,7 +58,7 @@ class PublishHandlerSpec
     Route.seal(PublishHandler.routes(ports))
 
   def createClient(routes: Route): PublishClient =
-    PublishClient.httpClient(Route.asyncHandler(routes))
+    PublishClient.httpClient(Route.toFunction(routes))
 
   val organizationId = 1
   val organizationNodeId = "N:organization:abc123"

--- a/server/src/test/scala/com/pennsieve/discover/handlers/SearchHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/SearchHandlerSpec.scala
@@ -40,7 +40,7 @@ class SearchHandlerSpec
     Route.seal(SearchHandler.routes(ports))
 
   def createClient(routes: Route): SearchClient =
-    SearchClient.httpClient(Route.asyncHandler(routes))
+    SearchClient.httpClient(Route.toFunction(routes))
 
   val searchClient: SearchClient = createClient(createRoutes())
 

--- a/server/src/test/scala/com/pennsieve/discover/handlers/SyncHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/SyncHandlerSpec.scala
@@ -22,7 +22,7 @@ class SyncHandlerSpec
     Route.seal(SyncHandler.routes(ports))
 
   def createSyncClient(routes: Route): SyncClient =
-    SyncClient.httpClient(Route.asyncHandler(routes))
+    SyncClient.httpClient(Route.toFunction(routes))
 
   val syncClient: SyncClient = createSyncClient(createRoutes())
 

--- a/server/src/test/scala/com/pennsieve/discover/handlers/TagHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/TagHandlerSpec.scala
@@ -24,7 +24,7 @@ class TagHandlerSpec
     Route.seal(TagHandler.routes(ports))
 
   def createClient(routes: Route): TagClient =
-    TagClient.httpClient(Route.asyncHandler(routes))
+    TagClient.httpClient(Route.toFunction(routes))
 
   val tagClient: TagClient = createClient(createRoutes())
 


### PR DESCRIPTION
This PR fixes the Akka dependency conflict introduced when we updated to Scala 2.13 by upgrading our Akka versions (as little as possible).

This project depends on service-utilities and the 2.13 version of that project is compiled against a newer version of akka-http which was causing a conflict in this project. So Akka and friends have been upgraded, not to the newest versions, but just enough to resolve the conflict.
