### PR TITLE
Update discover-service for custom publish buckets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,9 +42,9 @@ lazy val akkaHttpVersion = SettingKey[String]("akkaHttpVersion")
 lazy val akkaVersion = SettingKey[String]("akkaVersion")
 lazy val alpakkaVersion = SettingKey[String]("alpakkaVersion")
 
-lazy val akkaHttp213Version = "10.2.7"
-lazy val akka213Version = "2.6.8"
-lazy val alpakka213Version = "2.0.2"
+lazy val akkaHttp213Version = "10.2.9"
+lazy val akka213Version = "2.6.19"
+lazy val alpakka213Version = "4.0.0"
 lazy val akkaHttp212Version = "10.1.11"
 lazy val akka212Version = "2.6.5"
 lazy val alpakka212Version = "1.1.0"
@@ -158,7 +158,7 @@ lazy val server = project
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion,
       "com.sksamuel.elastic4s" %% "elastic4s-json-circe" % elastic4sVersion,
       "org.apache.commons" % "commons-lang3" % "3.9",
-      "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
+      "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.0",
       "org.scalikejdbc" %% "scalikejdbc" % "3.4.0",
       "com.zaneli" %% "scalikejdbc-athena" % "0.2.4",
       // Test dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ lazy val server = project
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
     ),*/
-      libraryDependencies ++= Seq (
+    libraryDependencies ++= Seq(
       "com.pennsieve" %% "service-utilities" % serviceUtilitiesVersion,
       "com.pennsieve" %% "utilities" % utilitiesVersion,
       "com.pennsieve" %% "auth-middleware" % authMiddlewareVersion,
@@ -141,6 +141,7 @@ lazy val server = project
       "software.amazon.awssdk" % "sfn" % awsSdkVersion,
       "software.amazon.awssdk" % "sns" % awsSdkVersion,
       "software.amazon.awssdk" % "s3" % awsSdkVersion,
+      "software.amazon.awssdk" % "sts" % awsSdkVersion,
       "com.github.pureconfig" %% "pureconfig" % pureConfigVersion,
       "com.github.pureconfig" %% "pureconfig-squants" % pureConfigVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -145,3 +145,9 @@ athena {
     AwsCredentialsProviderClass = ${?AWS_CREDENTIALS_PROVIDER_CLASS}
   }
 }
+external-publish-buckets = [
+    {
+        bucket = ${SPARC_PUBLISH_BUCKET}
+        role-arn = ${SPARC_BUCKET_ROLE_ARN}
+    }
+]

--- a/server/src/main/scala/com/pennsieve/discover/Config.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Config.scala
@@ -29,11 +29,16 @@ case class Config(
   sns: SNSConfiguration,
   pennsieveApi: PennsieveApiConfiguration,
   authorizationService: AuthorizationConfiguration,
-  download: DownloadConfiguration
+  download: DownloadConfiguration,
+  externalPublishBuckets: Map[S3Bucket, String] = Map.empty
 )
 
 object Config {
   implicit val awsRegionReader = ConfigReader[String].map(Region.of(_))
+  implicit val externalPublishBucketConfigurationReader
+    : ConfigReader[Map[S3Bucket, String]] =
+    ConfigReader[List[ExternalPublishBucketConfiguration]]
+      .map(_.map(c => c.bucket -> c.roleArn).toMap)
 
   def load: Config = ConfigSource.default.loadOrThrow[Config]
 }
@@ -103,3 +108,5 @@ case class ElasticSearchConfiguration(host: String, port: Int) {
 }
 
 case class SNSConfiguration(alertTopic: String, region: Region)
+
+case class ExternalPublishBucketConfiguration(bucket: S3Bucket, roleArn: String)

--- a/server/src/main/scala/com/pennsieve/discover/Config.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Config.scala
@@ -9,6 +9,7 @@ import squants.information.InformationConversions._
 import pureconfig._
 import pureconfig.module.squants._
 import pureconfig.generic.auto._
+import software.amazon.awssdk.arns.Arn
 
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
@@ -30,13 +31,14 @@ case class Config(
   pennsieveApi: PennsieveApiConfiguration,
   authorizationService: AuthorizationConfiguration,
   download: DownloadConfiguration,
-  externalPublishBuckets: Map[S3Bucket, String] = Map.empty
+  externalPublishBuckets: Map[S3Bucket, Arn] = Map.empty
 )
 
 object Config {
   implicit val awsRegionReader = ConfigReader[String].map(Region.of(_))
+  implicit val awsArnReader = ConfigReader[String].map(Arn.fromString(_))
   implicit val externalPublishBucketConfigurationReader
-    : ConfigReader[Map[S3Bucket, String]] =
+    : ConfigReader[Map[S3Bucket, Arn]] =
     ConfigReader[List[ExternalPublishBucketConfiguration]]
       .map(_.map(c => c.bucket -> c.roleArn).toMap)
 
@@ -109,4 +111,4 @@ case class ElasticSearchConfiguration(host: String, port: Int) {
 
 case class SNSConfiguration(alertTopic: String, region: Region)
 
-case class ExternalPublishBucketConfiguration(bucket: S3Bucket, roleArn: String)
+case class ExternalPublishBucketConfiguration(bucket: S3Bucket, roleArn: Arn)

--- a/server/src/main/scala/com/pennsieve/discover/Ports.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Ports.scala
@@ -120,7 +120,8 @@ object Ports {
         region = config.s3.region,
         frontendBucket = config.s3.frontendBucket,
         assetsKeyPrefix = config.s3.assetsKeyPrefix,
-        chunkSize = config.s3.chunkSize
+        chunkSize = config.s3.chunkSize,
+        externalPublishBucketToRole = config.externalPublishBuckets
       )
 
     val searchClient: SearchClient =

--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -176,7 +176,7 @@ class AssumeRoleResourceCache(val region: Region, stsClient: => StsClient) {
   ): StsAssumeRoleCredentialsProvider =
     roleToCredentialsProvider.computeIfAbsent(
       roleArn,
-      (r => createAssumeRoleCredentialsProvider(r)).asJava
+      (createAssumeRoleCredentialsProvider(_)).asJava
     )
 
   def getPresigner(roleArn: String): S3Presigner =

--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -150,14 +150,6 @@ trait S3StreamClient {
 
 class AssumeRoleResourceCache(val region: Region, stsClient: => StsClient) {
 
-  def this(region: Region) =
-    this(
-      region,
-      StsClient.builder
-        .region(region)
-        .build
-    )
-
   private val roleToCredentialsProvider =
     new ConcurrentHashMap[String, StsAssumeRoleCredentialsProvider]()
   private val roleToPresigner =

--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -24,7 +24,7 @@ import com.pennsieve.discover.downloads.ZipStream._
 import com.pennsieve.discover.models._
 import com.pennsieve.models._
 import com.pennsieve.discover.utils.joinPath
-import com.typesafe.scalalogging.StrictLogging
+import com.typesafe.scalalogging.{ LazyLogging, StrictLogging }
 import org.apache.commons.io.FilenameUtils
 import squants.information.Information
 import squants.information.InformationConversions._
@@ -148,7 +148,8 @@ trait S3StreamClient {
   def getPresignedUrlForFile(s3Bucket: S3Bucket, key: S3Key.File): String
 }
 
-class AssumeRoleResourceCache(val region: Region, stsClient: => StsClient) {
+class AssumeRoleResourceCache(val region: Region, stsClient: => StsClient)
+    extends LazyLogging {
 
   private val roleToCredentialsProvider =
     new ConcurrentHashMap[String, StsAssumeRoleCredentialsProvider]()
@@ -158,6 +159,7 @@ class AssumeRoleResourceCache(val region: Region, stsClient: => StsClient) {
   private def createAssumeRoleCredentialsProvider(
     roleArn: String
   ): StsAssumeRoleCredentialsProvider = {
+    logger.info(s"creating StsAssumeRoleCredentialsProvider for $roleArn")
     val assumeRoleRequest =
       AssumeRoleRequest
         .builder()

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -230,9 +230,10 @@ class SQSNotificationHandler(
   ): Future[Unit] =
     for {
       // Read the outputs.json file in S3
-      publishResult <- ports.s3StreamClient.readPublishJobOutput(version)
+      publishResult <- ports.s3StreamClient
+        .readPublishJobOutput(version, isRequesterPays = true)
       metadata <- ports.s3StreamClient
-        .readDatasetMetadata(version)
+        .readDatasetMetadata(version, isRequesterPays = true)
 
       // Update the dataset version with the information in outputs.json
       updatedVersion <- ports.db.run(
@@ -263,7 +264,8 @@ class SQSNotificationHandler(
       // Add dataset to search index
       _ <- Search.indexDataset(publicDataset, updatedVersion, ports)
 
-      _ <- ports.s3StreamClient.deletePublishJobOutput(updatedVersion)
+      _ <- ports.s3StreamClient
+        .deletePublishJobOutput(updatedVersion, isRequesterPays = true)
     } yield ()
 
   private def handleFailure(

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -231,9 +231,9 @@ class SQSNotificationHandler(
     for {
       // Read the outputs.json file in S3
       publishResult <- ports.s3StreamClient
-        .readPublishJobOutput(version, isRequesterPays = true)
+        .readPublishJobOutput(version)
       metadata <- ports.s3StreamClient
-        .readDatasetMetadata(version, isRequesterPays = true)
+        .readDatasetMetadata(version)
 
       // Update the dataset version with the information in outputs.json
       updatedVersion <- ports.db.run(
@@ -265,7 +265,7 @@ class SQSNotificationHandler(
       _ <- Search.indexDataset(publicDataset, updatedVersion, ports)
 
       _ <- ports.s3StreamClient
-        .deletePublishJobOutput(updatedVersion, isRequesterPays = true)
+        .deletePublishJobOutput(updatedVersion)
     } yield ()
 
   private def handleFailure(

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -1,0 +1,10 @@
+external-publish-buckets = [
+    {
+        bucket = "external-bucket-1"
+        role-arn = "external-role-1"
+    },
+    {
+        bucket = "external-bucket-2"
+        role-arn = "external-role-2"
+    },
+]

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -1,10 +1,10 @@
 external-publish-buckets = [
     {
         bucket = "external-bucket-1"
-        role-arn = "external-role-1"
+        role-arn = "arn:aws:iam::000000000000:role/external-bucket-1-access-role"
     },
     {
         bucket = "external-bucket-2"
-        role-arn = "external-role-2"
+        role-arn = "arn:aws:iam::999999999999:role/external-bucket-2-access-role"
     },
 ]

--- a/server/src/test/scala/com/pennsieve/discover/ConfigSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ConfigSpec.scala
@@ -6,6 +6,7 @@ import com.pennsieve.discover.models.S3Bucket
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.OptionValues._
+import software.amazon.awssdk.arns.Arn
 
 class ConfigSpec extends AnyWordSpec with Matchers {
 
@@ -17,7 +18,11 @@ class ConfigSpec extends AnyWordSpec with Matchers {
 
       config.externalPublishBuckets
         .get(S3Bucket("external-bucket-1"))
-        .value should be("external-role-1")
+        .value should be(
+        Arn.fromString(
+          "arn:aws:iam::000000000000:role/external-bucket-1-access-role"
+        )
+      )
 
       config.externalPublishBuckets
         .get(S3Bucket("default-bucket"))

--- a/server/src/test/scala/com/pennsieve/discover/ConfigSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ConfigSpec.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover
+
+import com.pennsieve.discover.models.S3Bucket
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.OptionValues._
+
+class ConfigSpec extends AnyWordSpec with Matchers {
+
+  "load" should {
+    "correctly parse the external-publish-buckets section" in {
+      val config: Config = Config.load
+
+      config.externalPublishBuckets.isEmpty should be(false)
+
+      config.externalPublishBuckets
+        .get(S3Bucket("external-bucket-1"))
+        .value should be("external-role-1")
+
+      config.externalPublishBuckets
+        .get(S3Bucket("default-bucket"))
+        .isDefined should be(false)
+    }
+  }
+}

--- a/server/src/test/scala/com/pennsieve/discover/DockerS3Service.scala
+++ b/server/src/test/scala/com/pennsieve/discover/DockerS3Service.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 trait DockerS3Service extends DockerKit with AwaitableImplicits {
 
-  val minioTag = "RELEASE.2019-04-23T23-50-36Z"
+  val minioTag = "RELEASE.2022-10-20T00-55-09Z"
   val accessKey: String = "access_key"
   val secretKey: String = "access_secret"
   val minioExposedPort: Int = 9000

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
@@ -93,7 +93,8 @@ class MockS3StreamClient extends S3StreamClient {
 ]}"""
 
   def datasetMetadataSource(
-    version: PublicDatasetVersion
+    version: PublicDatasetVersion,
+    isRequesterPays: Boolean = false
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
@@ -166,14 +167,16 @@ class MockS3StreamClient extends S3StreamClient {
     publishResults += key -> result
 
   def readPublishJobOutput(
-    version: PublicDatasetVersion
+    version: PublicDatasetVersion,
+    isRequesterPays: Boolean = false
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
   ): Future[PublishJobOutput] = Future(publishResults(version.s3Key))
 
   def deletePublishJobOutput(
-    version: PublicDatasetVersion
+    version: PublicDatasetVersion,
+    isRequesterPays: Boolean = false
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
@@ -93,8 +93,7 @@ class MockS3StreamClient extends S3StreamClient {
 ]}"""
 
   def datasetMetadataSource(
-    version: PublicDatasetVersion,
-    isRequesterPays: Boolean = false
+    version: PublicDatasetVersion
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
@@ -167,16 +166,14 @@ class MockS3StreamClient extends S3StreamClient {
     publishResults += key -> result
 
   def readPublishJobOutput(
-    version: PublicDatasetVersion,
-    isRequesterPays: Boolean = false
+    version: PublicDatasetVersion
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
   ): Future[PublishJobOutput] = Future(publishResults(version.s3Key))
 
   def deletePublishJobOutput(
-    version: PublicDatasetVersion,
-    isRequesterPays: Boolean = false
+    version: PublicDatasetVersion
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext

--- a/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
@@ -30,6 +30,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.EitherValues._
+import software.amazon.awssdk.arns.Arn
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.model.{
@@ -213,7 +214,9 @@ class S3StreamClientSpec
       val externalBucket = s"external-bucket-${UUID.randomUUID()}"
       val externalBucketConfig = ExternalPublishBucketConfiguration(
         S3Bucket(externalBucket),
-        "arn:aws:iam::000000000000:role/external-bucket-access-role"
+        Arn.fromString(
+          "arn:aws:iam::000000000000:role/external-bucket-access-role"
+        )
       )
       val (client, _, _) =
         createClient(externalPublishBucketConfig = Some(externalBucketConfig))

--- a/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
@@ -8,8 +8,11 @@ import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.testkit.scaladsl.TestSink
 import akka.util.ByteString
-import com.pennsieve.discover.S3Exception
-import com.pennsieve.discover.DockerS3Service
+import com.pennsieve.discover.{
+  DockerS3Service,
+  ExternalPublishBucketConfiguration,
+  S3Exception
+}
 import com.pennsieve.discover.models._
 import com.pennsieve.models._
 import com.pennsieve.test.AwaitableImplicits
@@ -39,6 +42,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.services.sts.StsClient
 import squants.information.Information
 import squants.information.InformationConversions._
 
@@ -114,11 +118,23 @@ class S3StreamClientSpec
     .endpointOverride(new URI(s3Endpoint))
     .build()
 
+  lazy val stsClient: StsClient = StsClient
+    .builder()
+    .region(Region.US_EAST_1)
+    .credentialsProvider(
+      StaticCredentialsProvider
+        .create(AwsBasicCredentials.create(accessKey, secretKey))
+    )
+    .endpointOverride(new URI(s3Endpoint))
+    .build()
+
   /**
     * Create a streaming client for testing, and the required S3 buckets.
     */
   def createClient(
-    chunkSize: Information = 20.megabytes
+    chunkSize: Information = 20.megabytes,
+    externalPublishBucketConfig: Option[ExternalPublishBucketConfiguration] =
+      None
   ): (AlpakkaS3StreamClient, String, String) = {
 
     val publishBucket = s"publish-bucket-${UUID.randomUUID()}"
@@ -127,12 +143,18 @@ class S3StreamClientSpec
     val frontendBucket = s"frontend-bucket-${UUID.randomUUID()}"
     createBucket(frontendBucket)
 
+    externalPublishBucketConfig.foreach(c => createBucket(c.bucket.value))
+    val bucketToRole =
+      externalPublishBucketConfig.map(c => c.bucket -> c.roleArn).toMap
+
     (
       new AlpakkaS3StreamClient(
-        Region.US_EAST_1,
+        s3Presigner,
+        stsClient,
         S3Bucket(frontendBucket),
         "dataset-assets",
-        chunkSize
+        chunkSize,
+        bucketToRole
       ),
       publishBucket,
       frontendBucket
@@ -183,6 +205,39 @@ class S3StreamClientSpec
 
       sink.request(n = 100)
       sink.expectNext(("dataset/files/file1.txt", ByteString("file1 data")))
+      sink.expectComplete()
+    }
+
+    "generate stream from external S3 publish bucket" in {
+      val externalBucket = s"external-bucket-${UUID.randomUUID()}"
+      val externalBucketConfig = ExternalPublishBucketConfiguration(
+        S3Bucket(externalBucket),
+        "arn:aws:iam::000000000000:role/external-bucket-access-role"
+      )
+      val (client, _, _) =
+        createClient(externalPublishBucketConfig = Some(externalBucketConfig))
+
+      // Data is even multiple of chunk size
+      putObject(externalBucket, "0/1/files/file1.txt", "file1 data")
+      // Not a multiple - last chunk is truncated
+      putObject(externalBucket, "0/1/files/file2.txt", "file2 data+")
+      putObject(externalBucket, "0/1/files/nested/file3.txt", "file3 data")
+
+      val sink = client
+        .datasetFilesSource(version(0, 1, externalBucket), "dataset")
+        .mapAsync(1) {
+          case (path, source) =>
+            source.runWith(Sink.fold(ByteString.empty)(_ ++ _)).map((path, _))
+        }
+        .toMat(TestSink.probe)(Keep.right)
+        .run()
+
+      sink.request(n = 100)
+      sink.expectNextUnordered(
+        ("dataset/files/file1.txt", ByteString("file1 data")),
+        ("dataset/files/file2.txt", ByteString("file2 data+")),
+        ("dataset/files/nested/file3.txt", ByteString("file3 data"))
+      )
       sink.expectComplete()
     }
   }

--- a/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
@@ -151,6 +151,7 @@ class S3StreamClientSpec
       new AlpakkaS3StreamClient(
         s3Presigner,
         stsClient,
+        Region.US_EAST_1,
         S3Bucket(frontendBucket),
         "dataset-assets",
         chunkSize,


### PR DESCRIPTION
Sets the requester pays header for S3 calls made by the SQSNotificationHandler as part of the publish workflow.

Update Akka & Alpakka version for Scala 2.13 to include requester pays bug fix on the server side.

For downloads we handle things differently and do not use the requester pays header.

In the external organization's AWS account: We require them to create a publish bucket access role in their account that has the necessary access to their publish bucket. They must also allow our discover-service task role to assume this role.

In our AWS account: We allow the discover-service task role to assume this external org's publish bucket access role. And we also create two parameters in the SSM parameter store. One for the bucket name and one for the publish bucket access role ARN. 

For downloads these new SSM parameters will be used in the discover-service config to create a map from bucket name to role ARN. Then when downloading or creating pre-signed URLs for files in an external org's bucket the discover-service task role will assume the corresponding external role instead of preforming the action as the task role.

For now the new AWS resources have been created manually for testing. There will need to be a follow up PR to add these resources to Terraform once they have been debugged.