### PR TITLE
Specify http client builder for synchronous AWS clients.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,6 +142,7 @@ lazy val server = project
       "software.amazon.awssdk" % "sns" % awsSdkVersion,
       "software.amazon.awssdk" % "s3" % awsSdkVersion,
       "software.amazon.awssdk" % "sts" % awsSdkVersion,
+      "software.amazon.awssdk" % "url-connection-client" % awsSdkVersion,
       "com.github.pureconfig" %% "pureconfig" % pureConfigVersion,
       "com.github.pureconfig" %% "pureconfig-squants" % pureConfigVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",

--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -42,6 +42,7 @@ import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import com.pennsieve.discover.models.Revision
 import software.amazon.awssdk.arns.Arn
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
@@ -219,6 +220,7 @@ class AlpakkaS3StreamClient(
         .build, // deliberately inlined to take advantage of call-by-name
       StsClient.builder
         .region(region)
+        .httpClientBuilder(UrlConnectionHttpClient.builder())
         .build, // deliberately inlined to take advantage of call-by-name
       region,
       frontendBucket,

--- a/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
@@ -43,6 +43,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient
 import software.amazon.awssdk.services.sts.StsClient
 import squants.information.Information
 import squants.information.InformationConversions._
@@ -107,6 +108,7 @@ class S3StreamClientSpec
           .create(AwsBasicCredentials.create(accessKey, secretKey))
       )
       .endpointOverride(new URI(s3Endpoint))
+      .httpClientBuilder(UrlConnectionHttpClient.builder())
       .build()
 
   lazy val s3Presigner: S3Presigner = S3Presigner
@@ -127,6 +129,7 @@ class S3StreamClientSpec
         .create(AwsBasicCredentials.create(accessKey, secretKey))
     )
     .endpointOverride(new URI(s3Endpoint))
+    .httpClientBuilder(UrlConnectionHttpClient.builder())
     .build()
 
   /**


### PR DESCRIPTION
When deployed, #23 failed when creating an StsClient because an http client builder could not be found on the classpath. 

This PR explicitly specifies UrlConnectionHttpClient.Builder when creating StsClient and other synchronous AWS clients.

I chose URLConnectionHttpClient over ApacheHttpClient for its faster start-up time given that we are not further configuring the http client. On the recommendation of this post: https://aws.amazon.com/blogs/developer/tuning-the-aws-java-sdk-2-x-to-reduce-startup-time/

(The ApacheHttpClient was already in our transitive dependencies and was used when running tests. But we might be excluding it from the artifact created by sbt-assembly via a merge strategy. Hence it's absence when actually running a deployed version.)