### PR TITLE
Include full publish/embargo bucket config in publish/release/unpublish requests

### DIFF
--- a/openapi/discover-service-internal.yml
+++ b/openapi/discover-service-internal.yml
@@ -266,7 +266,7 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/ReleaseRequest"
-        description: Object identifying custom publish bucket if it exists
+        description: Object identifying custom publish bucket configuration if it exists
         required: true
       responses:
         "202":
@@ -314,6 +314,13 @@ paths:
           schema:
             type: integer
             format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UnpublishRequest"
+        description: Object identifying custom publish bucket configuration if it exists
+        required: true
       responses:
         "200":
           description: Success
@@ -500,6 +507,20 @@ components:
       bearerFormat: JWT
 
   schemas:
+    BucketConfig:
+      description: Holds an organization's custom publish and embargo bucket names. Not used if organization does not use its own buckets.
+      type: object
+      required:
+        - publish
+        - embargo
+      properties:
+        publish:
+          description: name of the publish bucket
+          type: string
+        embargo:
+          description: name of the embargo bucket
+          type: string
+
     PublishRequest:
       type: object
       required:
@@ -574,17 +595,23 @@ components:
           type: string
         datasetNodeId:
           type: string
-        publishBucket:
-          type: string
-        embargoBucket:
-          type: string
+        bucketConfig:
+          description: The owning organization's custom bucket config. Omit if there is no such config
+          $ref: "#/components/schemas/BucketConfig"
 
     ReleaseRequest:
       type: object
       properties:
-        publishBucket:
-          description: The owning organization's custom publish bucket. Omit if there is no such bucket.
-          type: string
+        bucketConfig:
+          description: The owning organization's custom bucket config. Omit if there is no such config.
+          $ref: "#/components/schemas/BucketConfig"
+
+    UnpublishRequest:
+      type: object
+      properties:
+        bucketConfig:
+          description: The owning organization's custom bucket config. Omit if there is no such config.
+          $ref: "#/components/schemas/BucketConfig"
 
     ReviseRequest:
       type: object

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -149,5 +149,9 @@ external-publish-buckets = [
     {
         bucket = ${SPARC_PUBLISH_BUCKET}
         role-arn = ${SPARC_BUCKET_ROLE_ARN}
+    },
+    {
+        bucket = ${SPARC_EMBARGO_BUCKET}
+        role-arn = ${SPARC_BUCKET_ROLE_ARN}
     }
 ]

--- a/server/src/main/scala/com/pennsieve/discover/Errors.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Errors.scala
@@ -81,9 +81,13 @@ case class S3Exception(bucket: S3Bucket, key: S3Key) extends Throwable {
   override def getMessage: String = s"Error streaming s3://$bucket/$key"
 }
 
-case class LambdaException(s3KeyPrefix: String) extends Throwable {
+case class LambdaException(
+  s3KeyPrefix: String,
+  publishBucket: String,
+  embargoBucket: String
+) extends Throwable {
   override def getMessage: String =
-    s"Failed to run s3clean lambda function for s3_key_prefix=$s3KeyPrefix"
+    s"Failed to run s3clean lambda function for s3_key_prefix=$s3KeyPrefix, publish_bucket=$publishBucket, embargo_bucket=$embargoBucket"
 }
 
 case class BadQueryParameter(error: Throwable) extends Throwable {

--- a/server/src/main/scala/com/pennsieve/discover/models/EmbargoReleaseJob.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/EmbargoReleaseJob.scala
@@ -13,7 +13,8 @@ case class EmbargoReleaseJob(
   datasetId: Int,
   version: Int,
   s3Key: S3Key.Version,
-  s3Bucket: S3Bucket
+  publishBucket: S3Bucket,
+  embargoBucket: S3Bucket
 )
 
 object EmbargoReleaseJob {
@@ -21,26 +22,29 @@ object EmbargoReleaseJob {
   def apply(
     publicDataset: PublicDataset,
     version: PublicDatasetVersion,
-    s3Bucket: S3Bucket
+    publishBucket: S3Bucket,
+    embargoBucket: S3Bucket
   ): EmbargoReleaseJob =
     EmbargoReleaseJob(
       publicDataset.sourceOrganizationId,
       publicDataset.sourceDatasetId,
       version.version,
       version.s3Key,
-      s3Bucket
+      publishBucket,
+      embargoBucket
     )
 
   /**
     * Same with PublishJob, need custom encoder to convert all fields to strings.
     */
   implicit val encoder: Encoder[EmbargoReleaseJob] =
-    Encoder.forProduct5(
+    Encoder.forProduct6(
       "organization_id",
       "dataset_id",
       "version",
       "s3_key",
-      "s3_bucket"
+      "publish_bucket",
+      "embargo_bucket"
     )(
       j =>
         (
@@ -48,7 +52,8 @@ object EmbargoReleaseJob {
           j.datasetId.toString,
           j.version.toString,
           j.s3Key.value,
-          j.s3Bucket.toString
+          j.publishBucket.value,
+          j.embargoBucket.value
         )
     )
 }

--- a/server/src/main/scala/com/pennsieve/discover/models/PublishJob.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublishJob.scala
@@ -13,6 +13,15 @@ import io.circe.parser.decode
 
 /**
   * Job definition that is sent to the AWS State Machine.
+  *
+  * @param s3Bucket      this is the target bucket. Either a publish or embargo bucket.
+  * @param publishBucket this is either the owning organization's custom publish bucket or
+  *                      the default publish bucket if the organization does not have a custom
+  *                      bucket.
+  * @param embargoBucket this is either the owning organization's custom embargo bucket or
+  *                      the default embargo bucket if the organization does not have a custom
+  *                      bucket.
+
   */
 case class PublishJob(
   organizationId: Int,
@@ -33,7 +42,9 @@ case class PublishJob(
   doi: String,
   contributors: List[PublicContributor],
   collections: List[PublicCollection],
-  externalPublications: List[PublicExternalPublication]
+  externalPublications: List[PublicExternalPublication],
+  publishBucket: S3Bucket,
+  embargoBucket: S3Bucket
 )
 
 object PublishJob {
@@ -45,7 +56,9 @@ object PublishJob {
     doi: DoiDTO,
     contributors: List[PublicContributor],
     collections: List[PublicCollection],
-    externalPublications: List[PublicExternalPublication]
+    externalPublications: List[PublicExternalPublication],
+    publishBucket: S3Bucket,
+    embargoBucket: S3Bucket
   ): PublishJob = {
     PublishJob(
       organizationId = publicDataset.sourceOrganizationId,
@@ -66,7 +79,9 @@ object PublishJob {
       doi = doi.doi,
       contributors = contributors,
       collections = collections,
-      externalPublications = externalPublications
+      externalPublications = externalPublications,
+      publishBucket = publishBucket,
+      embargoBucket = embargoBucket
     )
   }
 
@@ -103,7 +118,7 @@ object PublishJob {
     * way to transform JSON types in Step Function input/output/result parameters.
     * Contributors are therefore encoded as a string rather than a collection fo objects
     */
-  implicit val encoder: Encoder[PublishJob] = Encoder.forProduct19(
+  implicit val encoder: Encoder[PublishJob] = Encoder.forProduct21(
     "organization_id",
     "organization_node_id",
     "organization_name",
@@ -122,7 +137,9 @@ object PublishJob {
     "doi",
     "contributors",
     "collections",
-    "external_publications"
+    "external_publications",
+    "publish_bucket",
+    "embargo_bucket"
   )(
     j =>
       (
@@ -144,7 +161,9 @@ object PublishJob {
         j.doi,
         j.contributors.asJson.noSpaces,
         j.collections.asJson.noSpaces,
-        j.externalPublications.asJson.noSpaces
+        j.externalPublications.asJson.noSpaces,
+        j.publishBucket.value,
+        j.embargoBucket.value
       )
   )
 }

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockLambdaClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockLambdaClient.scala
@@ -8,18 +8,25 @@ import software.amazon.awssdk.services.lambda.model.InvokeResponse
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ ExecutionContext, Future }
 
+case class LambdaRequest(
+  s3KeyPrefix: String,
+  publishBucket: String,
+  embargoBucket: String
+)
+
 class MockLambdaClient extends LambdaClient {
 
-  val s3Keys: ListBuffer[String] =
-    ListBuffer.empty[String]
+  val requests: ListBuffer[LambdaRequest] = ListBuffer.empty
 
   def runS3Clean(
-    s3KeyPrefix: String
+    s3KeyPrefix: String,
+    publishBucket: String,
+    embargoBucket: String
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
   ): Future[InvokeResponse] = {
-    this.s3Keys += s3KeyPrefix
+    this.requests += LambdaRequest(s3KeyPrefix, publishBucket, embargoBucket)
     Future.successful(InvokeResponse.builder().statusCode(200).build())
   }
 

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -110,11 +110,17 @@ class PublishHandlerSpec
       relationshipType = Some(RelationshipType.Describes)
     )
 
+  val customBucketConfig =
+    definitions.BucketConfig("org-publish-bucket", "org-embargo-bucket")
+
   val customBucketReleaseBody: definitions.ReleaseRequest =
-    definitions.ReleaseRequest(publishBucket = Some("org-custom-bucket"))
+    definitions.ReleaseRequest(bucketConfig = Some(customBucketConfig))
 
   val defaultBucketReleaseBody: definitions.ReleaseRequest =
     definitions.ReleaseRequest()
+
+  val defaultBucketUnpublishBody: definitions.UnpublishRequest =
+    definitions.UnpublishRequest()
 
   val requestBody: definitions.PublishRequest = definitions.PublishRequest(
     name = datasetName,
@@ -1135,7 +1141,8 @@ class PublishHandlerSpec
             organizationId = organizationId,
             datasetId = datasetId,
             version = version.version,
-            s3Bucket = S3Bucket(customBucketReleaseBody.publishBucket.get),
+            s3Bucket =
+              S3Bucket(customBucketReleaseBody.bucketConfig.get.publish),
             s3Key = version.s3Key
           )
       }
@@ -1214,7 +1221,7 @@ class PublishHandlerSpec
     "fail without a JWT" in {
 
       val response = client
-        .unpublish(organizationId, datasetId)
+        .unpublish(organizationId, datasetId, defaultBucketUnpublishBody)
         .awaitFinite()
         .value
 
@@ -1223,7 +1230,12 @@ class PublishHandlerSpec
 
     "fail with a user JWT" in {
       val response = client
-        .unpublish(organizationId, datasetId, userAuthToken)
+        .unpublish(
+          organizationId,
+          datasetId,
+          defaultBucketUnpublishBody,
+          userAuthToken
+        )
         .awaitFinite()
         .value
 
@@ -1261,7 +1273,12 @@ class PublishHandlerSpec
 
       val response =
         client
-          .unpublish(organizationId, datasetId, authToken)
+          .unpublish(
+            organizationId,
+            datasetId,
+            defaultBucketUnpublishBody,
+            authToken
+          )
           .awaitFinite()
           .value
           .asInstanceOf[UnpublishResponse.OK]
@@ -1288,7 +1305,12 @@ class PublishHandlerSpec
       )
 
       val response = client
-        .unpublish(organizationId, datasetId, authToken)
+        .unpublish(
+          organizationId,
+          datasetId,
+          defaultBucketUnpublishBody,
+          authToken
+        )
         .awaitFinite()
         .value
         .asInstanceOf[UnpublishResponse.OK]
@@ -1345,7 +1367,12 @@ class PublishHandlerSpec
       publishSuccessfully(publicDataset, version)
 
       val response = client
-        .unpublish(organizationId, datasetId, authToken)
+        .unpublish(
+          organizationId,
+          datasetId,
+          defaultBucketUnpublishBody,
+          authToken
+        )
         .awaitFinite()
         .value
         .asInstanceOf[UnpublishResponse.OK]
@@ -1377,7 +1404,12 @@ class PublishHandlerSpec
       )
 
       val response = client
-        .unpublish(organizationId, datasetId, authToken)
+        .unpublish(
+          organizationId,
+          datasetId,
+          defaultBucketUnpublishBody,
+          authToken
+        )
         .awaitFinite()
         .value
 
@@ -1395,7 +1427,12 @@ class PublishHandlerSpec
       )
 
       val response = client
-        .unpublish(organizationId, datasetId, authToken)
+        .unpublish(
+          organizationId,
+          datasetId,
+          defaultBucketUnpublishBody,
+          authToken
+        )
         .awaitFinite()
         .value
 
@@ -1413,7 +1450,12 @@ class PublishHandlerSpec
       )
 
       val response = client
-        .unpublish(organizationId, datasetId, authToken)
+        .unpublish(
+          organizationId,
+          datasetId,
+          defaultBucketUnpublishBody,
+          authToken
+        )
         .awaitFinite()
         .value
 
@@ -1426,7 +1468,12 @@ class PublishHandlerSpec
 
       val response =
         client
-          .unpublish(organizationId, datasetId, authToken)
+          .unpublish(
+            organizationId,
+            datasetId,
+            defaultBucketUnpublishBody,
+            authToken
+          )
           .awaitFinite()
           .value
 

--- a/server/src/test/scala/com/pennsieve/discover/models/JobEncodingSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/models/JobEncodingSpec.scala
@@ -64,7 +64,9 @@ class JobEncodingSpec extends AnyWordSpec with Suite with Matchers {
         doi = "10.324/4529",
         contributors = List(contrib1),
         collections = List(collection1),
-        externalPublications = List(externalPublication)
+        externalPublications = List(externalPublication),
+        publishBucket = S3Bucket("publish-bucket"),
+        embargoBucket = S3Bucket("embargo-bucket")
       )
 
       val json = job.asJson.toString
@@ -89,7 +91,9 @@ class JobEncodingSpec extends AnyWordSpec with Suite with Matchers {
           |  "doi" : "10.324/4529",
           |  "contributors" : "[{\\"id\\":1,\\"first_name\\":\\"Alfred\\",\\"middle_initial\\":\\"C\\",\\"last_name\\":\\"Kinsey\\",\\"degree\\":\\"Ph.D.\\",\\"orcid\\":null}]",
           |  "collections" : "[{\\"name\\":\\"My Awesome Collection\\",\\"source_collection_id\\":2,\\"dataset_id\\":1,\\"version_id\\":1}]",
-          |  "external_publications" : "[{\\"doi\\":\\"10.26275/t6j6-77pu\\",\\"relationshipType\\":\\"IsSourceOf\\"}]"
+          |  "external_publications" : "[{\\"doi\\":\\"10.26275/t6j6-77pu\\",\\"relationshipType\\":\\"IsSourceOf\\"}]",
+          |  "publish_bucket" : "publish-bucket",
+          |  "embargo_bucket" : "embargo-bucket"
           |}""".stripMargin
 
     }
@@ -99,7 +103,14 @@ class JobEncodingSpec extends AnyWordSpec with Suite with Matchers {
 
     "encode integers as strings" in {
       val job =
-        EmbargoReleaseJob(1, 10, 7, S3Key.Version(2, 5), S3Bucket("bucket"))
+        EmbargoReleaseJob(
+          1,
+          10,
+          7,
+          S3Key.Version(2, 5),
+          S3Bucket("publish-bucket"),
+          S3Bucket("embargo-bucket")
+        )
 
       job.asJson.toString shouldBe
         s"""{
@@ -107,7 +118,8 @@ class JobEncodingSpec extends AnyWordSpec with Suite with Matchers {
           |  "dataset_id" : "10",
           |  "version" : "7",
           |  "s3_key" : "2/5/",
-          |  "s3_bucket" : "bucket"
+          |  "publish_bucket" : "publish-bucket",
+          |  "embargo_bucket" : "embargo-bucket"
           |}""".stripMargin
     }
   }


### PR DESCRIPTION
The various publish related requests need to include both publish and embargo bucket names.

This PR adds this to the internal endpoint requests and so requires an update to the calling code in pennsieve-api.

The PR also updates the requests sent to the AWS Lambda and State Machine services so those pipelines have access to both publish and embargo bucket names.