### PR TITLE
Sparc doi redirect

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
@@ -18,7 +18,7 @@ object DoiRedirect {
 
   def getPublisher(publicDataset: PublicDataset): Option[String] = {
     if (publicDataset.sourceOrganizationName == "SPARC") {
-      Some("SPARC")
+      Some("SPARC Consortium")
     } else {
       Some("Pennsieve Discover")
     }

--- a/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
@@ -8,7 +8,7 @@ object DoiRedirect {
     publicDataset: PublicDataset,
     publicVersion: PublicDatasetVersion
   ): String = {
-    if (publicDataset.sourceOrganizationName == "SPARC Consortium" &&
+    if (publicDataset.sourceOrganizationName == "SPARC" &&
       publicDiscoverUrl == "https://discover.pennsieve.io") {
       getSPARCUrl(publicDataset.id, publicVersion.version)
     } else {
@@ -17,8 +17,8 @@ object DoiRedirect {
   }
 
   def getPublisher(publicDataset: PublicDataset): Option[String] = {
-    if (publicDataset.sourceOrganizationName == "SPARC Consortium") {
-      Some("SPARC Consortium")
+    if (publicDataset.sourceOrganizationName == "SPARC") {
+      Some("SPARC")
     } else {
       Some("Pennsieve Discover")
     }

--- a/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
@@ -8,7 +8,7 @@ object DoiRedirect {
     publicDataset: PublicDataset,
     publicVersion: PublicDatasetVersion
   ): String = {
-    if (publicDataset.sourceOrganizationName == "SPARC" &&
+    if ((publicDataset.sourceOrganizationName == "SPARC" || publicDataset.sourceOrganizationName == "SPARC Consortium") &&
       publicDiscoverUrl == "https://discover.pennsieve.io") {
       getSPARCUrl(publicDataset.id, publicVersion.version)
     } else {
@@ -17,7 +17,7 @@ object DoiRedirect {
   }
 
   def getPublisher(publicDataset: PublicDataset): Option[String] = {
-    if (publicDataset.sourceOrganizationName == "SPARC") {
+    if ((publicDataset.sourceOrganizationName == "SPARC" || publicDataset.sourceOrganizationName == "SPARC Consortium")) {
       Some("SPARC Consortium")
     } else {
       Some("Pennsieve Discover")


### PR DESCRIPTION
Given the new name for the SPARC organization on the platform.
We need to update the logic to point datasets with org SPARC or SPARC Consortium to sparc.science website