### PR TITLE
Testing fix for revise error

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -591,10 +591,11 @@ class AlpakkaS3StreamClient(
       (contentType, source) <- streamPresignedUrl(presignedUrl)
       _ = logger.info(s"read presigned url ${presignedUrl}")
       response <- source.runWith(
-        S3.multipartUpload(
+        S3.multipartUploadWithHeaders(
           frontendBucket.value,
           joinPath(assetsKeyPrefix, key.toString),
-          contentType = contentType
+          contentType = contentType,
+          s3Headers = S3Headers.empty
         )
       )
     } yield {


### PR DESCRIPTION
S3 seems to be complaining about an illegal header in a particular multipart upload where we are not setting any custom headers.

This PR explicitly sets the headers to empty to avoid Akka's default headers.