### PR TITLE
Don't count failed version when checking if DOI is a duplicate

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionsTable.scala
@@ -774,7 +774,11 @@ object PublicDatasetVersionsMapper
   )(implicit
     executionContext: ExecutionContext
   ): DBIOAction[Boolean, NoStream, Effect.Read] = {
-    this.filter(_.doi === doi).exists.result
+    this
+      .filter(_.doi === doi)
+      .filter(_.status inSet successfulStates)
+      .exists
+      .result
   }
 
   /**

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -813,7 +813,7 @@ class PublishHandlerSpec
         .createMockDoi(organizationId, datasetId)
         .doi
 
-      val failedVersion = TestUtilities.createNewDatasetVersion(ports.db)(
+      TestUtilities.createNewDatasetVersion(ports.db)(
         id = publicDataset.id,
         status = PublishFailed,
         doi = draftDoi


### PR DESCRIPTION
This fixes an issue where if the publish state machine fails, the original draft DOI is being replaced by a new DOI when the publish is retried.

The new DOI is created because it is already associated with a (failed) public_dataset_version row. This PR just updates the isDuplicateDoi query to take the version status into account.