### PR TITLE
Fix Glue DB and table definitions

### DIFF
--- a/terraform/glue.tf
+++ b/terraform/glue.tf
@@ -5,7 +5,7 @@ resource "aws_glue_catalog_database" "glue_catalog_database_s3_logs" {
 
 resource "aws_glue_catalog_table" "glue_catalog_table_s3_logs" {
   name          = "discover"
-  database_name = var.glue_db_name
+  database_name = aws_glue_catalog_database.glue_catalog_database_s3_logs.name
 
   table_type = "EXTERNAL_TABLE"
 


### PR DESCRIPTION
Terraform did not seem to understand that the Glue Table resource depended on the Glue DB resource, so attempting to make it clearer by referring to the DB resource in the table resource.