### PR TITLE
Remove redundant Glue DB definition

### DIFF
--- a/terraform/athena.tf
+++ b/terraform/athena.tf
@@ -1,5 +1,15 @@
 resource "aws_athena_database" "s3_access_logs_db" {
-  name   = "s3_access_logs_db"
+  name   = var.glue_db_name
   bucket = aws_ssm_parameter.athena_output_path.value
+}
+
+resource "aws_athena_data_catalog" "sparc_glue_catalog" {
+  name        = var.sparc_glue_catalog
+  description = "SPARC's Glue based Data Catalog"
+  type        = "GLUE"
+
+  parameters = {
+    "catalog-id" = data.terraform_remote_state.platform_infrastructure.outputs.sparc_account_id
   }
+}
   

--- a/terraform/glue.tf
+++ b/terraform/glue.tf
@@ -1,11 +1,7 @@
 # AWS Glue Table
-resource "aws_glue_catalog_database" "glue_catalog_database_s3_logs" {
-  name = var.glue_db_name
-}
-
 resource "aws_glue_catalog_table" "glue_catalog_table_s3_logs" {
   name          = "discover"
-  database_name = aws_glue_catalog_database.glue_catalog_database_s3_logs.name
+  database_name = aws_athena_database.s3_access_logs_db.name
 
   table_type = "EXTERNAL_TABLE"
 
@@ -152,12 +148,3 @@ resource "aws_glue_catalog_table" "glue_catalog_table_s3_logs" {
   }
 }
 
-resource "aws_athena_data_catalog" "sparc_glue_catalog" {
-  name        = var.sparc_glue_catalog
-  description = "SPARC's Glue based Data Catalog"
-  type        = "GLUE"
-
-  parameters = {
-    "catalog-id" = data.terraform_remote_state.platform_infrastructure.outputs.sparc_account_id
-  }
-}


### PR DESCRIPTION
There was an existing Athena DB resource defined which was conflicting with the new Glue DB resource definition when running apply.