### PR TITLE
GetDataCatalog Permission for the imported SPARC Data Catalog

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
@@ -30,12 +30,10 @@ class AthenaClientImpl(val pennsieveTable: String, val sparcTable: String)
     println(startDate)
     println(endDate)
     DB.athena { implicit s =>
-     /* sql"""${tableQuery(pennsieveTable, startDate, endDate)}
+      sql"""${tableQuery(pennsieveTable, startDate, endDate)}
             | UNION
             | ${tableQuery(sparcTable, startDate, endDate)}
-            | ORDER BY  dataset_id, version, dl_date;""".stripMargin*/
-      sql"""${tableQuery(sparcTable, startDate, endDate)}
-           | ORDER BY  dataset_id, version, dl_date;""".stripMargin
+            | ORDER BY  dataset_id, version, dl_date;""".stripMargin
         .map(
           rs =>
             DatasetDownload(

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -217,6 +217,15 @@ data "aws_iam_policy_document" "iam_policy_document" {
     ]
   }
 
+  statement {
+    sid       = "AllowAccessToSPARCDataCatalog"
+    effect    = "Allow"
+    actions   = ["athena:GetDataCatalog"]
+    resources = [
+      "arn:aws:athena:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:datacatalog/${aws_athena_data_catalog.sparc_glue_catalog.name}"
+    ]
+  }
+
   # statement {
   #   sid    = "PublishToVictorOps"
   #   effect = "Allow"


### PR DESCRIPTION
The Discover service role needs permission to get the imported SPARC Data Catalog in order to run an Athena query to gather download metrics.