### PR TITLE
Publishing 5.0 feature - defer delete of intermediate files

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -284,8 +284,9 @@ class SQSNotificationHandler(
       // Add dataset to search index
       _ <- Search.indexDataset(publicDataset, updatedVersion, ports)
 
-      _ <- ports.s3StreamClient
-        .deletePublishJobOutput(updatedVersion)
+      // TODO: delete all intermediate files
+//      _ <- ports.s3StreamClient
+//        .deletePublishJobOutput(updatedVersion)
     } yield ()
 
   private def publishFirstVersion(

--- a/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
@@ -160,9 +160,9 @@ class SQSNotificationHandlerSpec
       }
 
       // Should delete the outputs.json file
-      ports.s3StreamClient
-        .asInstanceOf[MockS3StreamClient]
-        .publishResults shouldBe empty
+//      ports.s3StreamClient
+//        .asInstanceOf[MockS3StreamClient]
+//        .publishResults shouldBe empty
 
       ports.pennsieveApiClient
         .asInstanceOf[MockPennsieveApiClient]


### PR DESCRIPTION
Do not delete `output.json` on **Notify  Success** stage