### PR TITLE
Publishing 5.0 feature - fix API endpoints

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
@@ -501,10 +501,19 @@ class DatasetHandler(
       } else {
         pathNoSchemeNoBucket
       }
-      path = if (!noSlashPath.startsWith(s"$datasetId/$versionId")) {
-        s"$datasetId/$versionId/$noSlashPath"
-      } else {
-        noSlashPath
+      path = version.migrated match {
+        case true =>
+          if (!noSlashPath.startsWith(s"$datasetId")) {
+            s"$datasetId/$noSlashPath"
+          } else {
+            noSlashPath
+          }
+        case false =>
+          if (!noSlashPath.startsWith(s"$datasetId/$versionId")) {
+            s"$datasetId/$versionId/$noSlashPath"
+          } else {
+            noSlashPath
+          }
       }
 
       file <- version.migrated match {

--- a/server/src/main/scala/com/pennsieve/discover/models/FileDownloadDTO.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/FileDownloadDTO.scala
@@ -25,7 +25,7 @@ case class FileDownloadDTO(
         })
         .getOrElse(path)
         .toVector,
-      s3Client.getPresignedUrlForFile(s3Bucket, s3Key),
+      s3Client.getPresignedUrlForFile(s3Bucket, s3Key, s3Version),
       size
     )
   }


### PR DESCRIPTION
- get file: correctly form S3 path for 5x published datasets (does not include version id)
- manifest of files download: provide S3 VersionId to PreSigner