### PR TITLE
Publishing 5.0 feature - invoke S3 Clean with 'Tidy'

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/LambdaClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/LambdaClient.scala
@@ -26,6 +26,7 @@ trait LambdaClient {
     s3KeyPrefix: String,
     publishBucket: String,
     embargoBucket: String,
+    cleanupStage: String,
     migrated: Boolean
   )(implicit
     system: ActorSystem,
@@ -52,6 +53,7 @@ class AlpakkaLambdaClient(
     s3KeyPrefix: String,
     publishBucket: String,
     embargoBucket: String,
+    cleanupStage: String,
     migrated: Boolean
   )(implicit
     system: ActorSystem,
@@ -72,7 +74,7 @@ class AlpakkaLambdaClient(
               "publish_bucket" -> publishBucket,
               "embargo_bucket" -> embargoBucket,
               "workflow_id" -> workflowId,
-              "cleanup_stage" -> "UNPUBLISH"
+              "cleanup_stage" -> cleanupStage
             ).asJson.noSpaces
           )
       )

--- a/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
@@ -1008,7 +1008,13 @@ class PublishHandler(
     embargoBucket: String,
     migrated: Boolean
   ): Future[InvokeResponse] = {
-    ports.lambdaClient.runS3Clean(s3Key, publishBucket, embargoBucket, migrated)
+    ports.lambdaClient.runS3Clean(
+      s3Key,
+      publishBucket,
+      embargoBucket,
+      S3CleanupStage.Unpublish,
+      migrated
+    )
   }
 
   private def deleteAssetsMulti(

--- a/server/src/main/scala/com/pennsieve/discover/models/S3CleanupStage.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/S3CleanupStage.scala
@@ -1,0 +1,10 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+object S3CleanupStage {
+  def Initial = "INITIAL"
+  def Failure = "FAILURE"
+  def Unpublish = "UNPUBLISH"
+  def Tidy = "TIDY"
+}

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -284,9 +284,15 @@ class SQSNotificationHandler(
       // Add dataset to search index
       _ <- Search.indexDataset(publicDataset, updatedVersion, ports)
 
-      // TODO: delete all intermediate files
-//      _ <- ports.s3StreamClient
-//        .deletePublishJobOutput(updatedVersion)
+      // invoke S3 Cleanup Lambda to delete publishing intermediate files
+      _ <- ports.lambdaClient.runS3Clean(
+        updatedVersion.s3Key.value,
+        updatedVersion.s3Bucket.value,
+        updatedVersion.s3Bucket.value,
+        S3CleanupStage.Tidy,
+        updatedVersion.migrated
+      )
+
     } yield ()
 
   private def publishFirstVersion(

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockLambdaClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockLambdaClient.scala
@@ -12,6 +12,7 @@ case class LambdaRequest(
   s3KeyPrefix: String,
   publishBucket: String,
   embargoBucket: String,
+  cleanupStage: String,
   migrated: Boolean
 )
 
@@ -23,6 +24,7 @@ class MockLambdaClient extends LambdaClient {
     s3KeyPrefix: String,
     publishBucket: String,
     embargoBucket: String,
+    cleanupStage: String,
     migrated: Boolean
   )(implicit
     system: ActorSystem,
@@ -32,6 +34,7 @@ class MockLambdaClient extends LambdaClient {
       s3KeyPrefix,
       publishBucket,
       embargoBucket,
+      cleanupStage,
       migrated
     )
     Future.successful(InvokeResponse.builder().statusCode(200).build())

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -1487,13 +1487,15 @@ class PublishHandlerSpec
 
       response.status shouldBe Unpublished
 
+      // Note: the S3 Clean Lambda is invoked at the end of Publish to "tidy," and at Unpublish time
       ports.lambdaClient
         .asInstanceOf[MockLambdaClient]
-        .requests should contain theSameElementsAs List(
+        .requests should contain atLeastOneElementOf List(
         LambdaRequest(
           publicDataset.id.toString,
           version.s3Bucket.value,
           version.s3Bucket.value,
+          S3CleanupStage.Unpublish,
           false
         )
       )
@@ -1574,11 +1576,12 @@ class PublishHandlerSpec
 
       ports.lambdaClient
         .asInstanceOf[MockLambdaClient]
-        .requests should contain theSameElementsAs List(
+        .requests should contain atLeastOneElementOf List(
         LambdaRequest(
           publicDataset.id.toString,
           v1.s3Bucket.value,
           v2.s3Bucket.value,
+          S3CleanupStage.Unpublish,
           false
         )
       )
@@ -1696,11 +1699,12 @@ class PublishHandlerSpec
 
       ports.lambdaClient
         .asInstanceOf[MockLambdaClient]
-        .requests should contain theSameElementsAs List(
+        .requests should contain atLeastOneElementOf List(
         LambdaRequest(
           publicDataset.id.toString,
           version.s3Bucket.value,
           version.s3Bucket.value,
+          S3CleanupStage.Unpublish,
           false
         )
       )


### PR DESCRIPTION
At the end of a successful Publishing, invoke S3 Clean Lambda with 'Tidy' action to delete publishing intermediate files.