### PR TITLE
Publishing 5.0 - fix Revision.s3Key

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -312,7 +312,9 @@ class AlpakkaS3StreamClient(
     version: PublicDatasetVersion,
     revision: Option[Revision]
   ): S3Key.File =
-    revision.map(_.s3Key / README_FILE).getOrElse(version.s3Key / README_FILE)
+    revision
+      .map(_.s3Key(version.migrated) / README_FILE)
+      .getOrElse(version.s3Key / README_FILE)
 
   private def outputKey(version: PublicDatasetVersion): S3Key.File =
     version.s3Key / "outputs.json"

--- a/server/src/main/scala/com/pennsieve/discover/models/Revision.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/Revision.scala
@@ -14,7 +14,8 @@ final case class Revision(
   updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
   id: Int = 0
 ) {
-  def s3Key: S3Key.Revision = S3Key.Revision(datasetId, version, revision)
+  def s3Key(migrated: Boolean = false): S3Key.Revision =
+    S3Key.Revision(datasetId, version, revision, migrated)
 }
 
 object Revision {


### PR DESCRIPTION
- needs some context on whether the Dataset Version is migrated