### PR TITLE
Publishing 5.0: add s3Version to API responses including File type

### DIFF
--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -1399,6 +1399,8 @@ components:
             createdAt:
               type: string
               format: date-time
+            s3Version:
+              type: string
 
     Directory:
       description: A directory containing files in the dataset


### PR DESCRIPTION
- updated OpenAPI spec
- include `s3Version` property on `#/components/schemas/File`