### PR TITLE
Ensure ltree labels do not contain illegal characters

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/db/PublicFileVersionsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicFileVersionsTable.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import com.github.tminglei.slickpg._
 import com.pennsieve.discover.{ NoFileException, NoFileVersionException }
 
-import java.util.{ Base64, UUID }
+import java.util.UUID
 import com.pennsieve.discover.db.profile.api._
 import com.pennsieve.discover.models.{
   FileDownloadDTO,
@@ -80,7 +80,7 @@ object PublicFileVersionsMapper
     key.value
       .split("/")
       .map(_.getBytes(StandardCharsets.UTF_8))
-      .map(Base64.getEncoder().withoutPadding().encodeToString(_))
+      .map(pgSafeBase64)
       .mkString(".")
   }
 

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicFilesTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicFilesTable.scala
@@ -30,7 +30,6 @@ import slick.jdbc.{
   SetParameter
 }
 
-import java.util.Base64
 import java.nio.charset.StandardCharsets
 import scala.concurrent.ExecutionContext
 
@@ -87,7 +86,7 @@ object PublicFilesMapper extends TableQuery(new PublicFilesTable(_)) {
     key.value
       .split("/")
       .map(_.getBytes(StandardCharsets.UTF_8))
-      .map(Base64.getEncoder().withoutPadding().encodeToString(_))
+      .map(pgSafeBase64)
       .mkString(".")
   }
 

--- a/server/src/main/scala/com/pennsieve/discover/db/package.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/package.scala
@@ -2,6 +2,22 @@
 
 package com.pennsieve.discover
 
+import java.util.Base64
+
 package object db {
   object profile extends PostgresProfile
+
+  // Our version of Postgres does not allow '+' or '/' in Ltree labels.
+  // But both are valid Base64 alphabet characters, so we need to switch them out unambiguously.
+  // The underscore is a legal ltree label character, but is not in the base 64 alphabet,
+  // so we use it to replace the characters Postgres does not like.
+  // (Later versions of Postgres apparently allow '-' in ltree labels, but not our version.)
+  def pgSafeBase64(bytes: Array[Byte]): String = {
+    Base64
+      .getEncoder()
+      .withoutPadding()
+      .encodeToString(bytes)
+      .replace("+", "_")
+      .replace("/", "__")
+  }
 }

--- a/server/src/test/scala/com/pennsieve/discover/db/PublicFilesMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/PublicFilesMapperSpec.scala
@@ -323,5 +323,87 @@ class PublicFilesMapperSpec
       )
       run(PublicFilesMapper.forVersion(version).length.result) shouldBe 100000
     }
+
+    "insert and find a file that would contain a '/' in it's base64 path encoding " in {
+      // We use base64 to encode path components as Postgres ltrees. However, Postgres does not
+      // allow '/' or '+' in ltree labels and these are legal base64. So we replace '+' with '_' and '/' with '__'.
+      // Underscore is not in the base64 alphabet, so this should be unambiguous.
+      val version = TestUtilities.createDatasetV1(ports.db)()
+
+      val expectedName = "0mmSD.mat"
+      val expectedSize = 100
+      val expectedPath =
+        "files/Jacobians/µa_0.035_mm-1___µs_15_mm-1_/0mmSD.mat"
+      val expectedS3Key = version.s3Key / expectedPath
+      val expectedPackageId = Some("N:package:3")
+      run(
+        PublicFilesMapper.create(
+          version,
+          expectedName,
+          "CSV",
+          expectedSize,
+          expectedS3Key,
+          expectedPackageId
+        )
+      )
+
+      run(PublicFilesMapper.childrenOf(version, None)) shouldBe (
+        (
+          TotalCount(1),
+          Seq(FileTreeNode.Directory("files", "files", expectedSize))
+        )
+      )
+
+      run(PublicFilesMapper.childrenOf(version, Some("files"))) shouldBe (
+        (
+          TotalCount(1),
+          Seq(
+            FileTreeNode.Directory("Jacobians", "files/Jacobians", expectedSize)
+          )
+        )
+      )
+
+      run(PublicFilesMapper.childrenOf(version, Some("files/Jacobians"))) shouldBe (
+        (
+          TotalCount(1),
+          Seq(
+            FileTreeNode.Directory(
+              "µa_0.035_mm-1___µs_15_mm-1_",
+              "files/Jacobians/µa_0.035_mm-1___µs_15_mm-1_",
+              expectedSize
+            )
+          )
+        )
+      )
+
+      run(
+        PublicFilesMapper.childrenOf(
+          version,
+          Some("files/Jacobians/µa_0.035_mm-1___µs_15_mm-1_")
+        )
+      ) shouldBe (
+        (
+          TotalCount(1),
+          Seq(
+            FileTreeNode.File(
+              expectedName,
+              expectedPath,
+              FileType.CSV,
+              expectedS3Key,
+              publishBucket,
+              expectedSize,
+              expectedPackageId
+            )
+          )
+        )
+      )
+
+      run(
+        PublicFilesMapper
+          .getFileDownloadsMatchingPaths(version, Seq(expectedPath))
+      ) shouldBe {
+        Seq(FileDownloadDTO(version, expectedName, expectedS3Key, expectedSize))
+      }
+    }
   }
 }

--- a/server/src/test/scala/com/pennsieve/discover/db/PublicFilesMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/PublicFilesMapperSpec.scala
@@ -325,9 +325,10 @@ class PublicFilesMapperSpec
     }
 
     "insert and find a file that would contain a '/' in it's base64 path encoding " in {
-      // We use base64 to encode path components as Postgres ltrees. However, Postgres does not
-      // allow '/' or '+' in ltree labels and these are legal base64. So we replace '+' with '_' and '/' with '__'.
-      // Underscore is not in the base64 alphabet, so this should be unambiguous.
+      // The path component containing 'µ' was chosen because in our initial method
+      // of ltree label creation it's label contained a '/' which Postgres does not allow
+      // in labels. This test verifies that the new method of ltree label creation avoids
+      // the '/' and results in a ltree path that still leaves the file findable.
       val version = TestUtilities.createDatasetV1(ports.db)()
 
       val expectedName = "0mmSD.mat"


### PR DESCRIPTION
This PR updates our ltree label creation method avoid having instances of `+` and `/` in our labels and instead use `_`(underscore) and `__`(double underscore) respectively.

Our current method of creating ltree labels is to Base64 encode each path component. This can result in a label containing `+` or `/`, but this causes a Postgres syntax error since those characters are not allowed in labels.

Since `_` is a legal ltree label character that is not a valid Base64 encoding character, the replacements should be unambiguous and backwards compatible. 

(Apparently, there is a Base64 variant that uses `-` and `_` instead of `+` and `/`, but our version of Postgres does not allow `-` in ltree labels either, so that is not currently an option. However, later versions of Postgres do allow hyphens, so it may be an option in the future.)

It does not seem like we ever go the other way, and decode a label back to a path component, so there is no change necessary there.

A test has been added to insert and search for a file that would otherwise have contained a `/` in its ltree path.