### PR TITLE
Fix Discover include changelog in revision

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -188,7 +188,7 @@ trait S3StreamClient {
     manifest: FileManifest,
     changelog: FileManifest
   ) {
-    def asList = List(banner, readme, manifest)
+    def asList = List(banner, readme, manifest, changelog)
   }
 
   def getPresignedUrlForFile(

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -939,12 +939,15 @@ class PublishHandlerSpec
 
       revisedVersion.status shouldBe PublishSucceeded
       revisedVersion.description shouldBe "Brief and succint."
-      revisedVersion.size shouldBe (76543 + 300) // From publish notification + new files
+      revisedVersion.size shouldBe (76543 + 400) // From publish notification + new files
       revisedVersion.banner shouldBe Some(
         revisedVersion.s3Key / s"revisions/${revision.revision}/banner.jpg"
       )
       revisedVersion.readme shouldBe Some(
         revisedVersion.s3Key / s"revisions/${revision.revision}/readme.md"
+      )
+      revisedVersion.changelog shouldBe Some(
+        revisedVersion.s3Key / s"revisions/${revision.revision}/changelog.md"
       )
 
       // Updates contributors table
@@ -1013,7 +1016,8 @@ class PublishHandlerSpec
             _.s3Key inSet List(
               revisedVersion.s3Key / s"revisions/${revision.revision}/manifest.json",
               revisedVersion.s3Key / s"revisions/${revision.revision}/readme.md",
-              revisedVersion.s3Key / s"revisions/${revision.revision}/banner.jpg"
+              revisedVersion.s3Key / s"revisions/${revision.revision}/banner.jpg",
+              revisedVersion.s3Key / s"revisions/${revision.revision}/changelog.md"
             )
           )
           .sortBy(_.name)
@@ -1022,6 +1026,7 @@ class PublishHandlerSpec
 
       createdFiles.map(f => (f.name, f.fileType)) shouldBe List(
         ("banner.jpg", "JPEG"),
+        ("changelog.md", "Markdown"),
         ("manifest.json", "Json"),
         ("readme.md", "Markdown")
       )


### PR DESCRIPTION
The `NewFiles` object created by the `S3StreamClient` was expanded to include the **changelog** `FileManifest`, however the `.asList()` method on the class was not including it. Its absence in the list was preventing the **changelog** being added to the `public_file_versions` table for the revision, and thus it was not present when the **browse** API endpoint was used.

The fix is to include the `changelog` in the result of the `.asList()` method

```scala
  case class NewFiles(
    banner: FileManifest,
    readme: FileManifest,
    manifest: FileManifest,
    changelog: FileManifest
  ) {
    def asList = List(banner, readme, manifest, changelog)
  }
```