### PR TITLE
Discover Service Updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@ node("executor") {
     def imageTag = "${env.BUILD_NUMBER}-${commitHash}"
 
     def sbt = "sbt -Dsbt.log.noformat=true -Dversion=$imageTag"
-    def sbtSetDockerApi = "$sbt -DDOCKER_API_VERSION='1.41'"
 
     def pennsieveNexusCreds = usernamePassword(
         credentialsId: "pennsieve-nexus-ci-login",
@@ -25,7 +24,7 @@ node("executor") {
         stage("Test") {
             withCredentials([pennsieveNexusCreds]) {
                 try {
-                    sh "$sbtSetDockerApi coverageOn +test"
+                    sh "$sbt coverageOn +test"
                 } finally {
                     junit '**/target/test-reports/*.xml'
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ node("executor") {
     def imageTag = "${env.BUILD_NUMBER}-${commitHash}"
 
     def sbt = "sbt -Dsbt.log.noformat=true -Dversion=$imageTag"
+    def sbtSetDockerApi = "$sbt -DDOCKER_API_VERSION='1.41'"
+
     def pennsieveNexusCreds = usernamePassword(
         credentialsId: "pennsieve-nexus-ci-login",
         usernameVariable: "PENNSIEVE_NEXUS_USER",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ node("executor") {
         stage("Test") {
             withCredentials([pennsieveNexusCreds]) {
                 try {
-                    sh "$sbt coverageOn +test"
+                    sh "$sbtSetDockerApi coverageOn +test"
                 } finally {
                     junit '**/target/test-reports/*.xml'
                 }

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -162,7 +162,7 @@ external-publish-buckets = [
         role-arn = ${SPARC_BUCKET_ROLE_ARN}
     },
     {
-        bucket = ${SPARC_EMBARGO__50_BUCKET}
+        bucket = ${SPARC_EMBARGO_50_BUCKET}
         role-arn = ${SPARC_BUCKET_ROLE_ARN}
     }
 ]

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -74,6 +74,10 @@ s-3 {
   access-logs-path = "dev/discover-publish/s3/"
   access-logs-path = ${?S3_ACCESS_LOGS_PATH}
   parallelism = 1
+  publish-50-bucket = "dev-discover-publish-use1"
+  publish-50-bucket = ${?S3_PUBLISH_50_BUCKET}
+  embargo-50-bucket = "dev-discover-embargo-use1"
+  embargo-50-bucket = ${?S3_EMBARGO_50_BUCKET}
 }
 
 sqs {

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -158,11 +158,11 @@ athena {
 
 external-publish-buckets = [
     {
-        bucket = ${SPARC_PUBLISH_BUCKET}
+        bucket = ${SPARC_PUBLISH_50_BUCKET}
         role-arn = ${SPARC_BUCKET_ROLE_ARN}
     },
     {
-        bucket = ${SPARC_EMBARGO_BUCKET}
+        bucket = ${SPARC_EMBARGO__50_BUCKET}
         role-arn = ${SPARC_BUCKET_ROLE_ARN}
     }
 ]

--- a/server/src/main/scala/com/pennsieve/discover/Config.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Config.scala
@@ -91,7 +91,9 @@ case class S3Configuration(
   assetsKeyPrefix: String,
   embargoBucket: S3Bucket,
   accessLogsPath: String,
-  chunkSize: Information = 20.megabytes
+  chunkSize: Information = 20.megabytes,
+  publish50Bucket: S3Bucket,
+  embargo50Bucket: S3Bucket
 )
 
 case class DownloadConfiguration(

--- a/server/src/main/scala/com/pennsieve/discover/handlers/FileHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/FileHandler.scala
@@ -10,7 +10,7 @@ import com.pennsieve.discover.server.file.{
   FileHandler => GuardrailHandler,
   FileResource => GuardrailResource
 }
-import com.pennsieve.discover.db.PublicFilesMapper
+import com.pennsieve.discover.db.{ PublicFileVersionsMapper, PublicFilesMapper }
 import com.pennsieve.discover.logging.{
   logRequestAndResponse,
   DiscoverLogContext
@@ -44,13 +44,11 @@ class FileHandler(
   ): Future[GuardrailResource.GetFileFromSourcePackageIdResponse] = {
 
     val query = for {
-
-      response <- PublicFilesMapper.getFileFromSourcePackageId(
+      response <- PublicFileVersionsMapper.getFileFromSourcePackageId(
         sourcePackageId,
         limit = limit.getOrElse(defaultFileLimit),
         offset = offset.getOrElse(defaultFileOffset)
       )
-
     } yield response
 
     ports.db

--- a/server/src/main/scala/com/pennsieve/discover/models/FileTreeNode.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/FileTreeNode.scala
@@ -40,6 +40,15 @@ object FileTreeNode {
       s3Key.toString
     }
 
+  def trimPath(s3Key: S3Key.File, datasetId: Int): String =
+    if (s3Key.toString
+        .startsWith(s"${datasetId}")) {
+      s3Key.toString
+        .replace(s"${datasetId}/", "")
+    } else {
+      s3Key.toString
+    }
+
   def apply(file: PublicFile, s3Bucket: S3Bucket): FileTreeNode = {
     File(
       file.name,
@@ -51,6 +60,20 @@ object FileTreeNode {
       file.sourcePackageId,
       Some(file.createdAt),
       s3Version = None
+    )
+  }
+
+  def apply(file: PublicFileVersion, s3Bucket: S3Bucket): FileTreeNode = {
+    File(
+      file.name,
+      trimPath(file.s3Key, file.datasetId),
+      utils.getFileType(file.fileType),
+      file.s3Key,
+      s3Bucket,
+      file.size,
+      file.sourcePackageId,
+      Some(file.createdAt),
+      s3Version = Some(file.s3Version)
     )
   }
 

--- a/server/src/test/resources/config-with-external-buckets.conf
+++ b/server/src/test/resources/config-with-external-buckets.conf
@@ -74,6 +74,10 @@ s-3 {
   access-logs-path = "dev/discover-publish/s3/"
   access-logs-path = ${?S3_ACCESS_LOGS_PATH}
   parallelism = 1
+  publish-50-bucket = "dev-discover-publish-use1"
+  publish-50-bucket = ${?S3_PUBLISH_50_BUCKET}
+  embargo-50-bucket = "dev-discover-embargo-use1"
+  embargo-50-bucket = ${?S3_EMBARGO_50_BUCKET}
 }
 
 sqs {

--- a/server/src/test/resources/config-without-external-buckets.conf
+++ b/server/src/test/resources/config-without-external-buckets.conf
@@ -74,6 +74,10 @@ s-3 {
   access-logs-path = "dev/discover-publish/s3/"
   access-logs-path = ${?S3_ACCESS_LOGS_PATH}
   parallelism = 1
+  publish-50-bucket = "dev-discover-publish-use1"
+  publish-50-bucket = ${?S3_PUBLISH_50_BUCKET}
+  embargo-50-bucket = "dev-discover-embargo-use1"
+  embargo-50-bucket = ${?S3_EMBARGO_50_BUCKET}
 }
 
 sqs {

--- a/server/src/test/scala/com/pennsieve/discover/ServerRoutesSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServerRoutesSpec.scala
@@ -33,14 +33,16 @@ class ServerRoutesSpec
 
       val v1 = TestUtilities.createDatasetV1(ports.db)(
         sourceOrganizationId = expectedOrgId,
-        status = PublishStatus.PublishSucceeded
+        status = PublishStatus.PublishSucceeded,
+        migrated = true
       )
 
-      val f1 = TestUtilities.createFile(ports.db)(
+      val f1 = TestUtilities.createFileVersion(ports.db)(
         v1,
         "A/file1.txt",
-        "TEXT",
-        sourcePackageId = Some(expectedPackageId)
+        FileType.Text,
+        sourcePackageId = Some(expectedPackageId),
+        s3Version = Some("fake-s3-version-id")
       )
 
       FileTreeWithOrgPage(
@@ -58,7 +60,8 @@ class ServerRoutesSpec
             createdAt = Some(f1.createdAt),
             fileType = FileType.Text,
             packageType = PackageType.Text,
-            icon = utils.getIcon(FileType.Text)
+            icon = utils.getIcon(FileType.Text),
+            s3Version = Some(f1.s3Version)
           )
         )
       )

--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -97,7 +97,9 @@ trait ServiceSpecHarness
         embargoBucket = S3Bucket("embargo-bucket"),
         publishLogsBucket = S3Bucket("publish-log-bucket"),
         accessLogsPath = "/logs/s3",
-        chunkSize = 20.megabytes
+        chunkSize = 20.megabytes,
+        publish50Bucket = S3Bucket("publish-bucket-05"),
+        embargo50Bucket = S3Bucket("embargo-bucket-50")
       ),
       sqs = SQSConfiguration(
         queueUrl = "http://localhost:9324/queue/test-queue",

--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -61,12 +61,7 @@ trait ServiceSpecHarness
 
   // provide a dockerFactory
   override implicit val dockerFactory: DockerFactory =
-    try new SpotifyDockerFactory(DefaultDockerClient.fromEnv().build())
-    catch {
-      case _: DockerException =>
-        throw new DockerException("Docker may not be running")
-    }
-
+    TestUtilities.dockerFactoryApiVersion141
   implicit val config: Config =
     Config(
       host = "0.0.0.0",

--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -98,7 +98,7 @@ trait ServiceSpecHarness
         publishLogsBucket = S3Bucket("publish-log-bucket"),
         accessLogsPath = "/logs/s3",
         chunkSize = 20.megabytes,
-        publish50Bucket = S3Bucket("publish-bucket-05"),
+        publish50Bucket = S3Bucket("publish-bucket-50"),
         embargo50Bucket = S3Bucket("embargo-bucket-50")
       ),
       sqs = SQSConfiguration(

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -13,6 +13,10 @@ import com.pennsieve.models.{
   PublishStatus
 }
 import com.pennsieve.test.AwaitableImplicits
+import com.spotify.docker.client.DefaultDockerClient
+import com.spotify.docker.client.exceptions.DockerException
+import com.whisk.docker.DockerFactory
+import com.whisk.docker.impl.spotify.SpotifyDockerFactory
 
 import java.nio.file.{ Files, Path }
 import java.util.UUID
@@ -374,5 +378,26 @@ object TestUtilities extends AwaitableImplicits {
         )
       )
       .await
+  }
+
+  /**
+    * Our tests use a Whisk library, that in turn uses a Spotify library, to manage
+    * docker containers created for tests. The Spotify part of this is no longer updated and breaks
+    * for newer versions of the Docker API. This creates a DockerFactory set to create clients that
+    * use a version of the API that works for us.
+    *
+    * @return a Spotify Docker client that will use version 1.41 of the Docker API
+    */
+  def dockerFactoryApiVersion141: DockerFactory = {
+    try new SpotifyDockerFactory(
+      DefaultDockerClient
+        .fromEnv()
+        .apiVersion("v1.41")
+        .build()
+    )
+    catch {
+      case _: DockerException =>
+        throw new DockerException("Docker may not be running")
+    }
   }
 }

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -197,7 +197,8 @@ object TestUtilities extends AwaitableImplicits {
     recordCount: Long = 10L,
     status: PublishStatus = PublishStatus.PublishInProgress,
     doi: String = randomString(),
-    embargoReleaseDate: Option[LocalDate] = None
+    embargoReleaseDate: Option[LocalDate] = None,
+    migrated: Boolean = false
   )(implicit
     executionContext: ExecutionContext
   ): PublicDatasetVersion = {
@@ -219,7 +220,8 @@ object TestUtilities extends AwaitableImplicits {
           schemaVersion = PennsieveSchemaVersion.`4.0`,
           banner = Some(S3Key.File("path-to-banner")),
           readme = Some(S3Key.File("path-to-readme")),
-          embargoReleaseDate = embargoReleaseDate
+          embargoReleaseDate = embargoReleaseDate,
+          migrated = migrated
         )
       )
       .await

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockServerS3StreamClientSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockServerS3StreamClientSpec.scala
@@ -7,7 +7,8 @@ import akka.http.scaladsl.model.Uri
 import com.pennsieve.discover.models._
 import com.pennsieve.discover.{
   DockerMockServerService,
-  ExternalPublishBucketConfiguration
+  ExternalPublishBucketConfiguration,
+  TestUtilities
 }
 import com.pennsieve.models._
 import com.pennsieve.test.AwaitableImplicits
@@ -78,11 +79,7 @@ class MockServerS3StreamClientSpec
     system.dispatcher
 
   override implicit val dockerFactory: DockerFactory =
-    try new SpotifyDockerFactory(DefaultDockerClient.fromEnv().build())
-    catch {
-      case _: DockerException =>
-        throw new DockerException("Docker may not be running")
-    }
+    TestUtilities.dockerFactoryApiVersion141
 
   lazy val s3Presigner: S3Presigner = S3Presigner
     .builder()

--- a/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
@@ -11,7 +11,8 @@ import akka.util.ByteString
 import com.pennsieve.discover.{
   DockerS3Service,
   ExternalPublishBucketConfiguration,
-  S3Exception
+  S3Exception,
+  TestUtilities
 }
 import com.pennsieve.discover.models._
 import com.pennsieve.models._
@@ -95,11 +96,7 @@ class S3StreamClientSpec
     system.dispatcher
 
   override implicit val dockerFactory: DockerFactory =
-    try new SpotifyDockerFactory(DefaultDockerClient.fromEnv().build())
-    catch {
-      case _: DockerException =>
-        throw new DockerException("Docker may not be running")
-    }
+    TestUtilities.dockerFactoryApiVersion141
 
   lazy val s3Presigner: S3Presigner = S3Presigner
     .builder()

--- a/server/src/test/scala/com/pennsieve/discover/handlers/FileHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/FileHandlerSpec.scala
@@ -41,33 +41,38 @@ class FileHandlerSpec
       val expectedOrgId = 3
       val v1 = TestUtilities.createDatasetV1(ports.db)(
         sourceOrganizationId = expectedOrgId,
-        status = PublishStatus.PublishSucceeded
+        status = PublishStatus.PublishSucceeded,
+        migrated = true
       )
 
       val v2 = TestUtilities.createNewDatasetVersion(ports.db)(
         id = v1.datasetId,
-        status = PublishSucceeded
+        status = PublishSucceeded,
+        migrated = true
       )
 
-      val f1 = TestUtilities.createFile(ports.db)(
+      val f1 = TestUtilities.createFileVersion(ports.db)(
         v2,
         "A/file1.txt",
-        "TEXT",
-        sourcePackageId = Some("N:package:1")
+        FileType.Text,
+        sourcePackageId = Some("N:package:1"),
+        s3Version = Some("s3-version-of-1")
       )
 
-      val f2 = TestUtilities.createFile(ports.db)(
+      val f2 = TestUtilities.createFileVersion(ports.db)(
         v2,
         "A/file2.txt",
-        "TEXT",
-        sourcePackageId = Some("N:package:1")
+        FileType.Text,
+        sourcePackageId = Some("N:package:1"),
+        s3Version = Some("s3-version-of-2")
       )
 
-      val f3 = TestUtilities.createFile(ports.db)(
+      val f3 = TestUtilities.createFileVersion(ports.db)(
         v1,
         "A/file3.txt",
-        "TEXT",
-        sourcePackageId = Some("N:package:1")
+        FileType.Text,
+        sourcePackageId = Some("N:package:1"),
+        s3Version = Some("s3-version-of-3")
       )
 
       val response = fileClient
@@ -89,7 +94,8 @@ class FileHandlerSpec
             createdAt = Some(f1.createdAt),
             fileType = FileType.Text,
             packageType = PackageType.Text,
-            icon = utils.getIcon(FileType.Text)
+            icon = utils.getIcon(FileType.Text),
+            s3Version = Some(f1.s3Version)
           ),
           client.definitions.File(
             name = f2.name,
@@ -100,7 +106,8 @@ class FileHandlerSpec
             createdAt = Some(f2.createdAt),
             fileType = FileType.Text,
             packageType = PackageType.Text,
-            icon = utils.getIcon(FileType.Text)
+            icon = utils.getIcon(FileType.Text),
+            s3Version = Some(f2.s3Version)
           )
         )
       )
@@ -112,28 +119,32 @@ class FileHandlerSpec
       val expectedOrgId = 4
       val v1 = TestUtilities.createDatasetV1(ports.db)(
         sourceOrganizationId = expectedOrgId,
-        status = PublishStatus.PublishSucceeded
+        status = PublishStatus.PublishSucceeded,
+        migrated = true
       )
 
-      val f1 = TestUtilities.createFile(ports.db)(
+      val f1 = TestUtilities.createFileVersion(ports.db)(
         v1,
         "A/file1.txt",
-        "TEXT",
-        sourcePackageId = Some("N:package:1")
+        FileType.Text,
+        sourcePackageId = Some("N:package:1"),
+        s3Version = Some("s3-version-of-1")
       )
 
-      val f2 = TestUtilities.createFile(ports.db)(
+      val f2 = TestUtilities.createFileVersion(ports.db)(
         v1,
         "A/file2.txt",
-        "TEXT",
-        sourcePackageId = Some("N:package:1")
+        FileType.Text,
+        sourcePackageId = Some("N:package:1"),
+        s3Version = Some("s3-version-of-2")
       )
 
-      val f3 = TestUtilities.createFile(ports.db)(
+      val f3 = TestUtilities.createFileVersion(ports.db)(
         v1,
         "A/file3.txt",
-        "TEXT",
-        sourcePackageId = Some("N:package:1")
+        FileType.Text,
+        sourcePackageId = Some("N:package:1"),
+        s3Version = Some("s3-version-of-3")
       )
 
       val response = fileClient
@@ -159,7 +170,8 @@ class FileHandlerSpec
             createdAt = Some(f2.createdAt),
             fileType = FileType.Text,
             packageType = PackageType.Text,
-            icon = utils.getIcon(FileType.Text)
+            icon = utils.getIcon(FileType.Text),
+            s3Version = Some(f2.s3Version)
           ),
           client.definitions.File(
             name = f3.name,
@@ -170,7 +182,8 @@ class FileHandlerSpec
             createdAt = Some(f3.createdAt),
             fileType = FileType.Text,
             packageType = PackageType.Text,
-            icon = utils.getIcon(FileType.Text)
+            icon = utils.getIcon(FileType.Text),
+            s3Version = Some(f3.s3Version)
           )
         )
       )

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -140,7 +140,8 @@ class PublishHandlerSpec
     ownerOrcid = ownerOrcid,
     organizationNodeId = organizationNodeId,
     organizationName = organizationName,
-    datasetNodeId = datasetNodeId
+    datasetNodeId = datasetNodeId,
+    workflowId = Some(4)
   )
 
   val customBucketRequestBody: definitions.PublishRequest =
@@ -1339,7 +1340,7 @@ class PublishHandlerSpec
             datasetId = datasetId,
             version = version.version,
             s3Key = version.s3Key,
-            publishBucket = config.s3.publishBucket,
+            publishBucket = config.s3.publish50Bucket,
             embargoBucket = version.s3Bucket
           )
       }

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -259,6 +259,18 @@ resource "aws_ssm_parameter" "sparc_embargo_bucket" {
   value = data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo_bucket_id
 }
 
+resource "aws_ssm_parameter" "sparc_publish_50_bucket" {
+  name  = "/${var.environment_name}/${var.service_name}/sparc-publish-50-bucket"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_id
+}
+
+resource "aws_ssm_parameter" "sparc_embargo_50_bucket" {
+  name  = "/${var.environment_name}/${var.service_name}/sparc-embargo-50-bucket"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_id
+}
+
 resource "aws_ssm_parameter" "sparc_bucket_role_arn" {
   name  = "/${var.environment_name}/${var.service_name}/sparc-bucket-role-arn"
   type  = "String"

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -102,6 +102,18 @@ resource "aws_ssm_parameter" "s3_embargo_bucket" {
   value = data.terraform_remote_state.platform_infrastructure.outputs.discover_embargo_bucket_id
 }
 
+resource "aws_ssm_parameter" "s3_publish_50_bucket" {
+  name  = "/${var.environment_name}/${var.service_name}/s3-publish-50-bucket"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.discover_publish50_bucket_id
+}
+
+resource "aws_ssm_parameter" "s3_embargo_50_bucket" {
+  name  = "/${var.environment_name}/${var.service_name}/s3-embargo-50-bucket"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.discover_embargo50_bucket_id
+}
+
 resource "aws_ssm_parameter" "s3_frontend_bucket" {
   name  = "/${var.environment_name}/${var.service_name}/s3-frontend-bucket"
   type  = "String"


### PR DESCRIPTION
Discover Service updates
- set Publishing 5.0 as the default workflow
- add default S3 Buckets for Publishing 5.0 workflow
- fix Get File by Source Package Id to work with Publishing 5.0 workflow datasets
- update external-buckets-config to point to Publishing 5.0 external buckets
