### PR TITLE
replace deprecated S3.download()

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -949,7 +949,7 @@ class AlpakkaS3StreamClient(
     ec: ExecutionContext
   ): Future[List[ReleaseAction]] =
     for {
-      (source, _) <- s3FileSource2(
+      (source, _) <- s3FileSource(
         version.s3Bucket,
         releaseResultKey(version),
         isRequesterPays = true
@@ -978,31 +978,6 @@ class AlpakkaS3StreamClient(
     system: ActorSystem,
     ec: ExecutionContext
   ): Future[(Source[ByteString, NotUsed], Long)] = {
-    S3.download(
-        bucket.value,
-        fileKey.value,
-        range = None,
-        versionId = s3Version,
-        s3Headers = s3Headers(isRequesterPays)
-      )
-      .runWith(Sink.head)
-      .flatMap {
-        case Some((source, content)) =>
-          Future.successful((source, content.getContentLength))
-        case None =>
-          Future.failed(S3Exception(bucket, fileKey))
-      }
-  }
-
-  def s3FileSource2(
-    bucket: S3Bucket,
-    fileKey: S3Key.File,
-    isRequesterPays: Boolean = false,
-    s3Version: Option[String] = None
-  )(implicit
-    system: ActorSystem,
-    ec: ExecutionContext
-  ): Future[(Source[ByteString, NotUsed], Long)] = {
     val s3Source: Source[ByteString, Future[ObjectMetadata]] = S3.getObject(
       bucket.value,
       fileKey.value,
@@ -1014,12 +989,15 @@ class AlpakkaS3StreamClient(
     val (metadataFuture, dataFuture) =
       s3Source.toMat(Sink.head)(Keep.both).run()
 
-    (metadataFuture.value.get, dataFuture.value.get) match {
-      case (Success(objectMetadata), Success(data)) =>
-        Future.successful((Source.single(data), objectMetadata.contentLength))
-      case (_, _) =>
-        Future.failed(S3Exception(bucket, fileKey))
-    }
+    for {
+      metadata <- metadataFuture.recoverWith(
+        _ => Future.failed(S3Exception(bucket, fileKey))
+      )
+      data <- dataFuture.recoverWith(
+        _ => Future.failed(S3Exception(bucket, fileKey))
+      )
+    } yield (Source.single(data), metadata.contentLength)
+
   }
 
   /**


### PR DESCRIPTION
Replaces the deprecated `S3.download()` function with `S3.getObject()`.

This capability is used in the `S3StreamClient` implementation class `AlpakkaS3StreamClient`, in two places:
- `s3FileSource()` is used by several entry points to download from S3 the manifest, readme, model source, and publishing intermediate files
- `datasetFilesSource()` streams published files into a ZIP by calling `downloadRange()` to download a range of bytes at a time

Included a test to ensure that `downloadRange()` retrieves the entirety of a large file (overrode `chunkSize` to get the effect of downloading large files in multiple parts with "smaller" large files).