### PR TITLE
Fix Athena query

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
@@ -57,12 +57,15 @@ class AthenaClientImpl(val pennsieveTable: String, val sparcTable: String)
     val escapedTableName = SQLSyntax.createUnsafely(tableName)
     //The discover table in the s3_access_logs_db is a column-for-column ingestion of the s3 access logs
     //An analysis of the logs showed that each full dataset download results in a row in the logs that always
-    // shows operation = 'REST.GET.BUCKET'. The url column of such rows also contain the dataset_id and version
+    // shows operation = 'REST.GET.BUCKET'. The url column of such rows also contain the dataset_id
     // passed as the prefix when it is a full dataset download. We take advantage of this in two places: in the
-    // select block to extract the dataset_id and version, but also in the WHERE block to reject other
+    // select block to extract the dataset_id, but also in the WHERE block to reject other
     // 'REST.GET.BUCKET' operations which are not dataset downloads and do not contain a dataset_id.
     // Likewise, we also remove rows where the requester column contains 's3clean' as those are linked to
     // unpublish actions.
+    // The version is set to zero since it is no longer included in the request_uri.
+    // This is part of a workaround we will use until a different method of tracking direct-from-S3 downloads
+    // is in place.
     sqls"""SELECT regexp_extract(request_uri,'.*prefix=(\d+)(?:%2F|\/).*', 1) AS dataset_id,
          |     0 AS version,
          |     date_parse(requestdatetime, '%d/%b/%Y:%H:%i:%S +%f') as dl_date,

--- a/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
@@ -63,14 +63,14 @@ class AthenaClientImpl(val pennsieveTable: String, val sparcTable: String)
     // 'REST.GET.BUCKET' operations which are not dataset downloads and do not contain a dataset_id.
     // Likewise, we also remove rows where the requester column contains 's3clean' as those are linked to
     // unpublish actions.
-    sqls"""SELECT regexp_extract(request_uri,'.*prefix=(\d+)(?:%2F|\/)(\d+)(:?%2F|\/).*', 1) AS dataset_id,
-         |     regexp_extract(request_uri, '.*prefix=(\d+)(?:%2F|\/)(\d+)(:?%2F|\/).*', 2) AS version,
+    sqls"""SELECT regexp_extract(request_uri,'.*prefix=(\d+)(?:%2F|\/).*', 1) AS dataset_id,
+         |     0 AS version,
          |     date_parse(requestdatetime, '%d/%b/%Y:%H:%i:%S +%f') as dl_date,
          |     requestid
          |FROM $escapedTableName
          |WHERE operation = 'REST.GET.BUCKET'
          |        AND requester NOT LIKE '%s3clean%'
-         |        AND regexp_extract(request_uri, '.*prefix=(\d+)(:?%2F|\/)(\d+)(:?%2F|\/).*', 1) is NOT null
+         |        AND regexp_extract(request_uri, '.*prefix=(\d+)(:?%2F|\/).*', 1) is NOT null
          |        AND date_parse(requestdatetime, '%d/%b/%Y:%H:%i:%S +%f') >= date_parse(${startDate.toString}, '%Y-%m-%d')
          |        AND date_parse(requestdatetime, '%d/%b/%Y:%H:%i:%S +%f') < date_parse(${endDate.toString}, '%Y-%m-%d')""".stripMargin
   }


### PR DESCRIPTION
PR is a temporary workaround that fixes the regex used in the download-metrics-gathering Athena query.

[BUG: Fix Athena query for download metrics
](https://app.clickup.com/t/86883nhx6)

Updates the query to remove the part that looked for a version number in the request_uri and to hardcode the version number to zero.

Ultimate solution for gathering these metrics is to replace the query with another method all together. But we can use this query temporarily to keep track of downloads of the most recent version of a dataset as well as partially recovering missed metrics since the change in the request_uri with the new publishing 5.0 workflow.