### PR TITLE
Feature/include checksum in file versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,7 +54,7 @@ lazy val circeVersion = SettingKey[String]("circeVersion")
 lazy val circe212Version = "0.11.1"
 lazy val circe213Version = "0.14.1"
 
-lazy val coreVersion = "283-dfa3dc9"
+lazy val coreVersion = "322-4a81ebb"
 lazy val authMiddlewareVersion = "5.1.3"
 lazy val serviceUtilitiesVersion = "8-9751ee3"
 lazy val utilitiesVersion = "4-55953e4"

--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -1408,6 +1408,8 @@ components:
               format: date-time
             s3Version:
               type: string
+            sha256:
+              type: string
 
     Directory:
       description: A directory containing files in the dataset
@@ -1564,6 +1566,8 @@ components:
           type: string
         size:
           type: number
+        sha256:
+          type: string
 
     DataUseAgreementDTO:
       type: object

--- a/server/src/main/resources/db/migration/V20240424114300__add_sha256_to_public_file_versions.sql
+++ b/server/src/main/resources/db/migration/V20240424114300__add_sha256_to_public_file_versions.sql
@@ -1,0 +1,4 @@
+/*
+** add `checksum` column to public_files_table
+*/
+ALTER TABLE public_file_versions add COLUMN sha256 varchar(255);

--- a/server/src/main/resources/db/migration/V20240424114300__add_sha256_to_public_file_versions.sql
+++ b/server/src/main/resources/db/migration/V20240424114300__add_sha256_to_public_file_versions.sql
@@ -1,4 +1,4 @@
 /*
 ** add `checksum` column to public_files_table
 */
-ALTER TABLE public_file_versions add COLUMN sha256 varchar(255);
+ALTER TABLE public_file_versions add COLUMN sha256 TEXT;

--- a/server/src/main/scala/com/pennsieve/discover/handlers/FileHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/FileHandler.scala
@@ -57,6 +57,9 @@ class FileHandler(
         case (total, _, Nil) =>
           GuardrailResource.GetFileFromSourcePackageIdResponse
             .NotFound(sourcePackageId)
+        case (_, None, _) =>
+          GuardrailResource.GetFileFromSourcePackageIdResponse
+            .NotFound(sourcePackageId)
         case (total, Some(organizationId), files) =>
           GuardrailResource.GetFileFromSourcePackageIdResponse
             .OK(

--- a/server/src/main/scala/com/pennsieve/discover/models/FileDownloadDTO.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/FileDownloadDTO.scala
@@ -11,7 +11,8 @@ case class FileDownloadDTO(
   s3Bucket: S3Bucket,
   s3Key: S3Key.File,
   size: Long,
-  s3Version: Option[String]
+  s3Version: Option[String],
+  sha256: Option[String]
 ) {
   def toDownloadResponseItem(
     s3Client: S3StreamClient,
@@ -26,7 +27,8 @@ case class FileDownloadDTO(
         .getOrElse(path)
         .toVector,
       s3Client.getPresignedUrlForFile(s3Bucket, s3Key, s3Version),
-      size
+      size,
+      sha256
     )
   }
 
@@ -53,7 +55,8 @@ case object FileDownloadDTO {
     name: String,
     s3Key: S3Key.File,
     size: Long,
-    s3Version: Option[String] = None
+    s3Version: Option[String] = None,
+    sha256: Option[String] = None
   ): FileDownloadDTO = {
     FileDownloadDTO(
       name,
@@ -61,7 +64,8 @@ case object FileDownloadDTO {
       version.s3Bucket,
       s3Key,
       size,
-      s3Version = s3Version
+      s3Version = s3Version,
+      sha256 = sha256
     )
   }
 

--- a/server/src/main/scala/com/pennsieve/discover/models/FileTreeNode.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/FileTreeNode.scala
@@ -25,7 +25,8 @@ object FileTreeNode {
     size: Long,
     sourcePackageId: Option[String],
     createdAt: Option[OffsetDateTime] = None,
-    s3Version: Option[String] = None
+    s3Version: Option[String] = None,
+    sha256: Option[String] = None
   ) extends FileTreeNode
 
   case class Directory(name: String, path: String, size: Long)
@@ -59,7 +60,8 @@ object FileTreeNode {
       file.size,
       file.sourcePackageId,
       Some(file.createdAt),
-      s3Version = None
+      s3Version = None,
+      sha256 = None
     )
   }
 
@@ -73,7 +75,8 @@ object FileTreeNode {
       file.size,
       file.sourcePackageId,
       Some(file.createdAt),
-      s3Version = Some(file.s3Version)
+      s3Version = Some(file.s3Version),
+      sha256 = file.sha256
     )
   }
 
@@ -90,7 +93,8 @@ object FileTreeNode {
       file.size,
       file.sourcePackageId,
       Some(file.createdAt),
-      s3Version = Some(file.s3Version)
+      s3Version = Some(file.s3Version),
+      sha256 = file.sha256
     )
   }
 }

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicFileVersion.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicFileVersion.scala
@@ -18,7 +18,8 @@ case class PublicFileVersion(
   path: LTree,
   createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
   updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
-  datasetId: Int
+  datasetId: Int,
+  sha256: Option[String] = None
 )
 
 object PublicFileVersion {


### PR DESCRIPTION
Added the `sha256` column to the `public_file_versions` table. When provided in a `FileManifest`, the column will be populated with the value.

Added `sha256` to the API responses for **GetFile** and **DownloadManifest**.
