### PR TITLE
Fix: Athena Sync version mapping

### DIFF
--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -208,6 +208,10 @@ trait ServiceSpecHarness
       .requests
       .clear()
 
+    ports.athenaClient
+      .asInstanceOf[MockAthenaClient]
+      .reset()
+
     // Clear dataset tables
     ports.db
       .run(for {

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockAthenaClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockAthenaClient.scala
@@ -15,47 +15,54 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 class MockAthenaClient extends AthenaClient {
 
+  private val defaultDatasetDownloads = List(
+    DatasetDownload(
+      1,
+      1,
+      Some(DownloadOrigin.AWSRequesterPayer),
+      Some("REQID2"),
+      OffsetDateTime.of(
+        LocalDateTime
+          .of(LocalDate.of(2020, 11, 10), LocalTime.of(19, 3, 1)),
+        ZoneOffset.UTC
+      )
+    ),
+    DatasetDownload(
+      1,
+      1,
+      Some(DownloadOrigin.AWSRequesterPayer),
+      Some("REQID3"),
+      OffsetDateTime.of(
+        LocalDateTime
+          .of(LocalDate.of(2020, 11, 10), LocalTime.of(18, 3, 1)),
+        ZoneOffset.UTC
+      )
+    ),
+    DatasetDownload(
+      1,
+      1,
+      Some(DownloadOrigin.AWSRequesterPayer),
+      Some("REQID1"),
+      OffsetDateTime.of(
+        LocalDateTime
+          .of(LocalDate.of(2020, 11, 10), LocalTime.of(10, 3, 1)),
+        ZoneOffset.UTC
+      )
+    )
+  )
+
+  var datasetDownloadsForRange: Option[List[DatasetDownload]] = None
+
+  def reset() = {
+    datasetDownloadsForRange = None
+  }
+
   def getDatasetDownloadsForRange(
     startDate: LocalDate,
     endDate: LocalDate
   )(implicit
     ec: ExecutionContext
-  ): List[DatasetDownload] = {
-    List(
-      DatasetDownload(
-        1,
-        1,
-        Some(DownloadOrigin.AWSRequesterPayer),
-        Some("REQID2"),
-        OffsetDateTime.of(
-          LocalDateTime
-            .of(LocalDate.of(2020, 11, 10), LocalTime.of(19, 3, 1)),
-          ZoneOffset.UTC
-        )
-      ),
-      DatasetDownload(
-        1,
-        1,
-        Some(DownloadOrigin.AWSRequesterPayer),
-        Some("REQID3"),
-        OffsetDateTime.of(
-          LocalDateTime
-            .of(LocalDate.of(2020, 11, 10), LocalTime.of(18, 3, 1)),
-          ZoneOffset.UTC
-        )
-      ),
-      DatasetDownload(
-        1,
-        1,
-        Some(DownloadOrigin.AWSRequesterPayer),
-        Some("REQID1"),
-        OffsetDateTime.of(
-          LocalDateTime
-            .of(LocalDate.of(2020, 11, 10), LocalTime.of(10, 3, 1)),
-          ZoneOffset.UTC
-        )
-      )
-    )
-  }
+  ): List[DatasetDownload] =
+    datasetDownloadsForRange.getOrElse(defaultDatasetDownloads)
 
 }

--- a/server/src/test/scala/com/pennsieve/discover/handlers/SyncHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/SyncHandlerSpec.scala
@@ -116,7 +116,7 @@ class SyncHandlerSpec
       )
 
       val reqId2DownloadTimeInLocal = convertToLocalOffset(
-        OffsetDateTime.of(2020, 11, 10, 19, 3, 1, 0, ZoneOffset.UTC)
+        OffsetDateTime.of(2020, 11, 10, 19, 3, 1, 0, ZoneOffset.UTC) // this is the downloadedAt time of req2 which the MockAthenaClient will return
       )
 
       responseMetrics shouldBe
@@ -146,13 +146,13 @@ class SyncHandlerSpec
       )
       val req2 = DatasetDownload(
         ds1.datasetId,
-        0,
+        0, // this should be replaced by ds1V2.version when it is inserted into Postgres
         Some(DownloadOrigin.AWSRequesterPayer),
         Some("REQID2"),
         OffsetDateTime.of(2020, 11, 10, 10, 3, 6, 0, ZoneOffset.UTC)
       )
       val req3 = DatasetDownload(
-        0,
+        0, // this 0 means that it should be ignored since it cannot be inserted into Postgres (violates foreign key constraint)
         1,
         Some(DownloadOrigin.AWSRequesterPayer),
         Some("REQID3"),


### PR DESCRIPTION
PR modifies the `DatasetDownload` results returned by the Athena client in two ways in the`/metrics/dataset/athena/download/sync` back end.

1. Removes `DatasetDownloads` with a datasetId of zero. These appear because of a `/0/` S3 key prefix in our publish buckets used for testing but which do not correspond to datasets in Postgres and so should not be counted in the metrics.
2.The Athena query is no longer able to fill in the version of the dataset being downloaded. Instead all `DatasetDownloads` coming from the Athena client have version set to zero. So the second change is to look up the most recent version of the dataset and replace the 0 version with the that version.

Also adds a test to verify these two changes.