### PR TITLE
fetch updated RDS CA certificate bundle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,20 +191,12 @@ lazy val server = project
     docker / dockerfile := {
       val artifact: File = assembly.value
       val artifactTargetPath = s"/app/${artifact.name}"
-      new Dockerfile {
-        from("pennsieve/java-cloudwrap:10-jre-slim-0.5.9")
+      new SecureDockerfile("pennsieve/java-cloudwrap:10-jre-slim-0.5.9") {
         copy(artifact, artifactTargetPath, chown = "pennsieve:pennsieve")
         copy(
           baseDirectory.value / "bin" / "run.sh",
           "/app/run.sh",
           chown = "pennsieve:pennsieve"
-        )
-        run("mkdir", "-p", "/home/pennsieve/.postgresql")
-        run(
-          "wget",
-          "-qO",
-          "/home/pennsieve/.postgresql/root.crt",
-          "https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem"
         )
         run(
           "wget",
@@ -287,16 +279,8 @@ lazy val syncElasticSearch = project
     docker / dockerfile := {
       val artifact: File = assembly.value
       val artifactTargetPath = s"/app/${artifact.name}"
-      new Dockerfile {
-        from("pennsieve/java-cloudwrap:8-jre-alpine-0.5.9")
+      new SecureDockerfile("pennsieve/java-cloudwrap:8-jre-alpine-0.5.9") {
         copy(artifact, artifactTargetPath, chown = "pennsieve:pennsieve")
-        run("mkdir", "-p", "/home/pennsieve/.postgresql")
-        run(
-          "wget",
-          "-qO",
-          "/home/pennsieve/.postgresql/root.crt",
-          "https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem"
-        )
         // Reuse discover-service tag so this container has access to service's environment
         cmd(
           "--service",

--- a/project/SecureDockerfile.scala
+++ b/project/SecureDockerfile.scala
@@ -1,0 +1,17 @@
+import sbtdocker.Dockerfile
+
+// A Dockerfile that contains the AWS RDS CA root certificate
+// Assumes the current user is pennsieve
+abstract class SecureDockerfile(image: String) extends Dockerfile {
+  // Where Postgres (psql/JDBC) expects to find the trusted CA certificate
+  val CA_CERT_LOCATION = "/home/pennsieve/.postgresql/root.crt"
+
+  from(image)
+  addRaw(
+    "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
+    CA_CERT_LOCATION,
+  )
+  user("root")
+  run("chmod", "+r", CA_CERT_LOCATION)
+  user("pennsieve")
+}


### PR DESCRIPTION
## Description
**ClickUp Ticket:** [8688dguvj](https://app.clickup.com/t/8688dguvj)

Upgrading the CA we pull down to trust when connecting to our PostgreSQL database using `ssl_mode=verify-ca`. The old CA is set to expire in August 2024 so we will need to upgrade our RDS CA. This change allows us to do that without introducing downtime.

## Testing
Built and ran the image locally to ensure the new CA cert bundle was put in the right location.

Tested using the bundle separately:
- locally (from the dev jump box) using the bundled PEM in place of the single expiring certificate.
- with a JDBC connection via the pennsieve-api repo in: https://github.com/Pennsieve/pennsieve-api/pull/287