### PR TITLE
Adds RE-JOIN and Precision buckets

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -142,6 +142,9 @@ athena {
     sparc-bucket-access-table = "sparc_glue_catalog.dev_s3_access_logs_db.discover"
     sparc-bucket-access-table = ${?SPARC_BUCKET_ACCESS_GLUE_TABLE}
 
+    rejoin-bucket-access-table = "rejoin_glue_catalog.dev_s3_access_logs_db.discover"
+    rejoin-bucket-access-table = ${?REJOIN_BUCKET_ACCESS_GLUE_TABLE}
+
   default {
     driver = "com.simba.athena.jdbc.Driver"
     driver = ${?ATHENA_DRIVER}
@@ -157,6 +160,7 @@ athena {
 }
 
 external-publish-buckets = [
+    # SPARC Buckets
     {
         bucket = ${SPARC_PUBLISH_50_BUCKET}
         role-arn = ${SPARC_BUCKET_ROLE_ARN}
@@ -164,5 +168,23 @@ external-publish-buckets = [
     {
         bucket = ${SPARC_EMBARGO_50_BUCKET}
         role-arn = ${SPARC_BUCKET_ROLE_ARN}
-    }
+    },
+    # RE-JOIN Buckets
+    {
+        bucket = ${REJOIN_PUBLISH_50_BUCKET}
+        role-arn = ${REJOIN_BUCKET_ROLE_ARN}
+    },
+    {
+        bucket = ${REJOIN_EMBARGO_50_BUCKET}
+        role-arn = ${REJOIN_BUCKET_ROLE_ARN}
+    },
+    # PRECISION Buckets (in same account as RE-JOIN, both use same role ARN)
+    {
+        bucket = ${PRECISION_PUBLISH_50_BUCKET}
+        role-arn = ${REJOIN_BUCKET_ROLE_ARN}
+    },
+    {
+        bucket = ${PRECISION_EMBARGO_50_BUCKET}
+        role-arn = ${REJOIN_BUCKET_ROLE_ARN}
+    },
 ]

--- a/server/src/main/scala/com/pennsieve/discover/Config.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Config.scala
@@ -123,5 +123,6 @@ case class ExternalPublishBucketConfiguration(bucket: S3Bucket, roleArn: Arn)
 
 case class AthenaConfig(
   pennsieveBucketAccessTable: String,
-  sparcBucketAccessTable: String
+  sparcBucketAccessTable: String,
+  rejoinBucketAccessTable: String
 )

--- a/server/src/main/scala/com/pennsieve/discover/Ports.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Ports.scala
@@ -141,7 +141,8 @@ object Ports {
 
     val athenaClient: AthenaClient = new AthenaClientImpl(
       pennsieveTable = config.athena.pennsieveBucketAccessTable,
-      sparcTable = config.athena.sparcBucketAccessTable
+      sparcTable = config.athena.sparcBucketAccessTable,
+      rejoinTable = config.athena.rejoinBucketAccessTable
     )
 
     Ports(

--- a/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
@@ -18,8 +18,11 @@ trait AthenaClient {
   ): List[DatasetDownload]
 }
 
-class AthenaClientImpl(val pennsieveTable: String, val sparcTable: String)
-    extends AthenaClient {
+class AthenaClientImpl(
+  val pennsieveTable: String,
+  val sparcTable: String,
+  val rejoinTable: String
+) extends AthenaClient {
 
   def getDatasetDownloadsForRange(
     startDate: LocalDate,
@@ -33,6 +36,8 @@ class AthenaClientImpl(val pennsieveTable: String, val sparcTable: String)
       sql"""${tableQuery(pennsieveTable, startDate, endDate)}
             | UNION
             | ${tableQuery(sparcTable, startDate, endDate)}
+            | UNION
+            | ${tableQuery(rejoinTable, startDate, endDate)}
             | ORDER BY  dataset_id, version, dl_date;""".stripMargin
         .map(
           rs =>

--- a/server/src/test/resources/config-with-external-buckets.conf
+++ b/server/src/test/resources/config-with-external-buckets.conf
@@ -138,6 +138,8 @@ akka {
 athena {
     pennsieve-bucket-access-table = "s3_access_logs_db.discover"
     sparc-bucket-access-table = "sparc_dev_catalog.dev_discover_s3_access_logs_db.discover_logs"
+    rejoin-bucket-access-table = "rejoin_dev_catalog.dev_discover_s3_access_logs_db.discover_logs"
+
   default {
     driver = "com.simba.athena.jdbc.Driver"
     driver = ${?ATHENA_DRIVER}

--- a/server/src/test/resources/config-without-external-buckets.conf
+++ b/server/src/test/resources/config-without-external-buckets.conf
@@ -138,6 +138,8 @@ akka {
 athena {
     pennsieve-bucket-access-table = "s3_access_logs_db.discover"
     sparc-bucket-access-table = "sparc_dev_catalog.dev_discover_s3_access_logs_db.discover_logs"
+    rejoin-bucket-access-table = "rejoin_dev_catalog.dev_discover_s3_access_logs_db.discover_logs"
+
   default {
     driver = "com.simba.athena.jdbc.Driver"
     driver = ${?ATHENA_DRIVER}

--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -112,7 +112,9 @@ trait ServiceSpecHarness
       athena = AthenaConfig(
         pennsieveBucketAccessTable = "s3_access_logs_db.discover",
         sparcBucketAccessTable =
-          "sparc_glue_catalog.dev_s3_access_logs_db.discover"
+          "sparc_glue_catalog.dev_s3_access_logs_db.discover",
+        rejoinBucketAccessTable =
+          "rejoin_glue_catalog.dev_s3_access_logs_db.discover"
       )
     )
 

--- a/server/src/test/scala/com/pennsieve/discover/integration/AthenaClientIntegrationSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/integration/AthenaClientIntegrationSpec.scala
@@ -30,7 +30,8 @@ class AthenaClientIntegrationSpec
 
       val athenaClient: AthenaClient = new AthenaClientImpl(
         pennsieveTable = config.athena.pennsieveBucketAccessTable,
-        sparcTable = config.athena.sparcBucketAccessTable
+        sparcTable = config.athena.sparcBucketAccessTable,
+        rejoinTable = config.athena.rejoinBucketAccessTable
       )
 
       val athenaDownloads = athenaClient.getDatasetDownloadsForRange(

--- a/terraform/athena.tf
+++ b/terraform/athena.tf
@@ -12,4 +12,14 @@ resource "aws_athena_data_catalog" "sparc_glue_catalog" {
     "catalog-id" = data.terraform_remote_state.platform_infrastructure.outputs.sparc_account_id
   }
 }
+
+resource "aws_athena_data_catalog" "rejoin_glue_catalog" {
+  name        = var.rejoin_glue_catalog
+  description = "RE-JOIN (and Precision)'s Glue based Data Catalog"
+  type        = "GLUE"
+
+  parameters = {
+    "catalog-id" = data.terraform_remote_state.platform_infrastructure.outputs.rejoin_account_id
+  }
+}
   

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -187,7 +187,15 @@ data "aws_iam_policy_document" "iam_policy_document" {
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn,
-      "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn}/*"
+      "${data.terraform_remote_state.platform_infrastructure.outputs.sparc_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn}/*"
     ]
   }
 
@@ -222,7 +230,10 @@ data "aws_iam_policy_document" "iam_policy_document" {
     sid       = "AssumeSPARCPublishBucketRole"
     effect    = "Allow"
     actions   = ["sts:AssumeRole"]
-    resources = [data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn]
+    resources = [
+      data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn
+    ]
   }
 
   statement {

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -276,6 +276,37 @@ resource "aws_ssm_parameter" "sparc_bucket_role_arn" {
   type  = "String"
   value = data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn
 }
+//    RE-JOIN
+resource "aws_ssm_parameter" "rejoin_publish_50_bucket" {
+  name  = "/${var.environment_name}/${var.service_name}/rejoin-publish-50-bucket"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.rejoin_publish50_bucket_id
+}
+
+resource "aws_ssm_parameter" "rejoin_embargo_50_bucket" {
+  name  = "/${var.environment_name}/${var.service_name}/rejoin-embargo-50-bucket"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.rejoin_embargo50_bucket_id
+}
+
+resource "aws_ssm_parameter" "rejoin_bucket_role_arn" {
+  name  = "/${var.environment_name}/${var.service_name}/rejoin-bucket-role-arn"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn
+}
+//    Precision
+resource "aws_ssm_parameter" "precision_publish_50_bucket" {
+  name  = "/${var.environment_name}/${var.service_name}/precision-publish-50-bucket"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_id
+}
+
+resource "aws_ssm_parameter" "precision_embargo_50_bucket" {
+  name  = "/${var.environment_name}/${var.service_name}/precision-embargo-50-bucket"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_id
+}
+
 
 // ATHENA CONFIGURATION
 resource "aws_ssm_parameter" "pennsieve_bucket_access_glue_table" {
@@ -288,6 +319,12 @@ resource "aws_ssm_parameter" "sparc_bucket_access_glue_table" {
   name  = "/${var.environment_name}/${var.service_name}/sparc-bucket-access-glue-table"
   type  = "String"
   value = "${var.sparc_glue_catalog}.${data.terraform_remote_state.platform_infrastructure.outputs.sparc_s3_access_logs_glue_db}.${data.terraform_remote_state.platform_infrastructure.outputs.sparc_s3_access_logs_glue_table}"
+}
+
+resource "aws_ssm_parameter" "rejoin_bucket_access_glue_table" {
+  name  = "/${var.environment_name}/${var.service_name}/rejoin-bucket-access-glue-table"
+  type  = "String"
+  value = "${var.sparc_glue_catalog}.${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_glue_db}.${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_glue_table}"
 }
 
 // SNS CONFIGURATION

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,6 +35,10 @@ variable "sparc_glue_catalog" {
   default = "sparc_glue_catalog"
 }
 
+variable "rejoin_glue_catalog" {
+  default = "rejoin_glue_catalog"
+}
+
 locals {
   java_opts = [
     "-javaagent:/app/newrelic.jar",


### PR DESCRIPTION
- Updates Terraform with permissions and other required information to access new custom buckets for RE-JOIN and Precision.
- Updates config mapping of custom bucket -> external role to include those new custom buckets.
- Updates Athena client to include the aws-rejoin Glue table in the Athena metrics query.