### PR TITLE
Fix/publishing finalize with many files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -138,6 +138,7 @@ lazy val server = project
       "com.lightbend.akka" %% "akka-stream-alpakka-s3" % alpakkaVersion.value,
       "com.lightbend.akka" %% "akka-stream-alpakka-awslambda" % alpakkaVersion.value,
       "com.lightbend.akka" %% "akka-stream-alpakka-csv" % alpakkaVersion.value,
+      "com.lightbend.akka" %% "akka-stream-alpakka-slick" % alpakkaVersion.value,
       "software.amazon.awssdk" % "lambda" % awsSdkVersion,
       "software.amazon.awssdk" % "sfn" % awsSdkVersion,
       "software.amazon.awssdk" % "sns" % awsSdkVersion,

--- a/server/src/main/scala/com/pennsieve/discover/Ports.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Ports.scala
@@ -7,6 +7,7 @@ import com.pennsieve.auth.middleware.Jwt
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.Materializer._
+import akka.stream.alpakka.slick.scaladsl.SlickSession
 import com.pennsieve.discover.clients.{
   AlpakkaLambdaClient,
   AlpakkaS3StreamClient,
@@ -25,6 +26,7 @@ import com.pennsieve.discover.clients.{
   SearchClient,
   StepFunctionsClient
 }
+import com.pennsieve.discover.db.profile
 import com.pennsieve.service.utilities.{
   ContextLogger,
   LogContext,
@@ -54,6 +56,8 @@ case class Ports(
 ) {
   val logger: ContextLogger = new ContextLogger()
   val log: LoggerTakingImplicit[LogContext] = logger.context
+  val slickSession: SlickSession =
+    SlickSession.forDbAndProfile(db, profile)
 }
 
 object Ports {

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionFilesTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionFilesTable.scala
@@ -35,6 +35,22 @@ object PublicDatasetVersionFilesTableMapper
     ) {
 
   def storeLink(
+    datasetId: Int,
+    datasetVersion: Int,
+    fileId: Int
+  )(implicit
+    executionContext: ExecutionContext
+  ): DBIOAction[
+    PublicDatasetVersionFile,
+    NoStream,
+    Effect.Write with Effect.Transactional with Effect
+  ] = (this returning this) += PublicDatasetVersionFile(
+    datasetId = datasetId,
+    datasetVersion = datasetVersion,
+    fileId = fileId
+  )
+
+  def storeLink(
     version: PublicDatasetVersion,
     fileVersion: PublicFileVersion
   )(implicit

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicFileVersionsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicFileVersionsTable.scala
@@ -14,7 +14,6 @@ import com.pennsieve.discover.models.{
   FileTreeNode,
   PublicDatasetVersion,
   PublicDatasetVersionFile,
-  PublicDatasetVersionFileVersion,
   PublicFile,
   PublicFileVersion,
   ReleaseAction,
@@ -193,29 +192,6 @@ object PublicFileVersionsMapper
         .transactionally
     )
 
-//  def create(
-//    version: PublicDatasetVersion,
-//    name: String,
-//    fileType: String,
-//    size: Long,
-//    s3Key: S3Key.File,
-//    sourcePackageId: Option[String] = None
-//  )(implicit
-//    executionContext: ExecutionContext
-//  ): DBIOAction[
-//    PublicFile,
-//    NoStream,
-//    Effect.Read with Effect.Write with Effect.Transactional with Effect
-//  ] =
-//    (this returning this) += buildFile(
-//      version = version,
-//      name = name,
-//      fileType = fileType,
-//      size = size,
-//      s3Key = s3Key,
-//      sourcePackageId = sourcePackageId
-//    )
-
   def getFile(
     version: PublicDatasetVersion,
     path: S3Key.File
@@ -349,13 +325,6 @@ object PublicFileVersionsMapper
     } yield (allFileVersions)
   }
 
-  //  def forVersion(
-  //                  version: PublicDatasetVersion
-  //                ): Query[PublicFileVersionsTable, PublicFile, Seq] =
-  //    this
-  //      .filter(_.version === version.version)
-  //      .filter(_.datasetId === version.datasetId)
-
   def create(
     fileVersion: PublicFileVersion
   )(implicit
@@ -458,152 +427,6 @@ object PublicFileVersionsMapper
       case Success(s) => DBIO.successful(s)
     }.transactionally
   }
-
-  def insert(
-    pfv: PublicFileVersion
-  )(implicit
-    executionContext: ExecutionContext
-  ): DBIOAction[
-    Int,
-    NoStream,
-    Effect.Read with Effect.Write with Effect.Transactional
-  ] = {
-    val action = (
-      this
-        .filter(_.datasetId === pfv.datasetId)
-        .filter(_.s3Key === pfv.s3Key)
-        .filter(_.s3Version === pfv.s3Version)
-        .result
-        .headOption
-        .flatMap {
-          case Some(fileVersion) => DBIO.successful(fileVersion.id)
-          case None =>
-            (this returning this.map(_.id)) +=
-              PublicFileVersion(
-                name = pfv.name,
-                fileType = pfv.fileType,
-                size = pfv.size,
-                sourcePackageId = pfv.sourcePackageId,
-                sourceFileUUID = pfv.sourceFileUUID,
-                s3Key = pfv.s3Key,
-                s3Version = pfv.s3Version,
-                path = pfv.path,
-                datasetId = pfv.datasetId,
-                sha256 = pfv.sha256
-              )
-//            val item = id.map {
-//              id =>
-//                PublicFileVersion(
-//                  id = id,
-//                  name = pfv.name,
-//                  fileType = pfv.fileType,
-//                  size = pfv.size,
-//                  sourcePackageId = pfv.sourcePackageId,
-//                  sourceFileUUID = pfv.sourceFileUUID,
-//                  s3Key = pfv.s3Key,
-//                  s3Version = pfv.s3Version,
-//                  path = pfv.path,
-//                  datasetId = pfv.datasetId,
-//                  sha256 = pfv.sha256
-//                )
-//            }
-//            item
-        }
-      )
-      .transactionally
-    action
-  }
-
-//  def connect(
-//    versionAndFile: PublicDatasetVersionFileVersion
-//  )(implicit
-//    executionContext: ExecutionContext
-//  ): DBIOAction[
-//    PublicFileVersion,
-//    NoStream,
-//    Effect.Read with Effect.Write with Effect.Transactional
-//  ] = {
-//    val pfv = versionAndFile.file
-//    val version = versionAndFile.version
-//    val action = (
-//      this
-//        .filter(_.datasetId === pfv.datasetId)
-//        .filter(_.s3Key === pfv.s3Key)
-//        .filter(_.s3Version === pfv.s3Version)
-//        .result
-//        .headOption
-//        .flatMap {
-//          case Some(fileVersion) =>
-//            DBIO.successful(fileVersion)
-////            val item = (PublicDatasetVersionFilesTableMapper returning PublicDatasetVersionFilesTableMapper) += PublicDatasetVersionFile(
-////              version.datasetId,
-////              version.version,
-////              fileVersion.id
-////            )
-////            DBIO.successful(item.map(item => item.fileId))
-//          case None =>
-//            val item = (this returning this) +=
-//              PublicFileVersion(
-//                name = pfv.name,
-//                fileType = pfv.fileType,
-//                size = pfv.size,
-//                sourcePackageId = pfv.sourcePackageId,
-//                sourceFileUUID = pfv.sourceFileUUID,
-//                s3Key = pfv.s3Key,
-//                s3Version = pfv.s3Version,
-//                path = pfv.path,
-//                datasetId = pfv.datasetId,
-//                sha256 = pfv.sha256
-//              )
-//            item.map(item => DBIO.successful(item))
-////            val fileId = id.
-////            val item = id.map(
-////              id =>
-////                (PublicDatasetVersionFilesTableMapper returning PublicDatasetVersionFilesTableMapper) += PublicDatasetVersionFile(
-////                  version.datasetId,
-////                  version.version,
-////                  id
-////                )
-////            )
-////            DBIO.successful(item.map(item => item.map(item => item.fileId)))
-//        }
-//      )
-//      .transactionally
-//    action
-//  }
-
-//  def insertIfNotExists(productInput: ProductInput): Future[DBProduct] = {
-//
-//    val productAction = (
-//      products.filter(_.uuid===productInput.uuid).result.headOption.flatMap {
-//        case Some(product) =>
-//          mylog("product was there: " + product)
-//          DBIO.successful(product)
-//
-//        case None =>
-//          mylog("inserting product")
-//
-//          val productId =
-//            (products returning products.map(_.id)) += DBProduct(
-//              0,
-//              productInput.uuid,
-//              productInput.name,
-//              productInput.price
-//            )
-//
-//          val product = productId.map { id => DBProduct(
-//            id,
-//            productInput.uuid,
-//            productInput.name,
-//            productInput.price
-//          )
-//          }
-//          product
-//      }
-//      ).transactionally
-//
-//    db.run(productAction)
-//  }
 
   def setS3Version(
     fileVersion: PublicFileVersion,

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicFileVersion.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicFileVersion.scala
@@ -25,3 +25,8 @@ case class PublicFileVersion(
 object PublicFileVersion {
   val tupled = (this.apply _).tupled
 }
+
+case class PublicDatasetVersionFileVersion(
+  version: PublicDatasetVersion,
+  file: PublicFileVersion
+)

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicFileVersion.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicFileVersion.scala
@@ -25,8 +25,3 @@ case class PublicFileVersion(
 object PublicFileVersion {
   val tupled = (this.apply _).tupled
 }
-
-case class PublicDatasetVersionFileVersion(
-  version: PublicDatasetVersion,
-  file: PublicFileVersion
-)

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotification.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotification.scala
@@ -29,20 +29,6 @@ object SQSNotificationType
 
 import SQSNotificationType._
 
-sealed trait PublishNotificationAction extends EnumEntry with Lowercase
-object PublishNotificationAction
-    extends Enum[PublishNotificationAction]
-    with CirceEnum[PublishNotificationAction] {
-  val values = findValues
-
-  case object ALL extends PublishNotificationAction
-  case object NOTIFY_API extends PublishNotificationAction
-  case object PUBLISH_DOI extends PublishNotificationAction
-  case object STORE_FILES extends PublishNotificationAction
-  case object INDEX extends PublishNotificationAction
-  case object S3_CLEAN extends PublishNotificationAction
-}
-
 /**
   * Generic job type that Discover reads from the SQS queue.
   *
@@ -111,8 +97,7 @@ case class PublishNotification(
   datasetId: Int,
   status: PublishStatus, // TODO: remove this and send "success" boolean from step function
   version: Int,
-  error: Option[String] = None,
-  action: PublishNotificationAction = PublishNotificationAction.ALL
+  error: Option[String] = None
 ) extends SQSNotification
     with JobDoneNotification {
 
@@ -157,21 +142,6 @@ object PublishNotification {
           )
         }
     }
-
-  def shouldPerform(
-    step: PublishNotificationAction,
-    requested: PublishNotificationAction
-  ): Boolean = {
-    import PublishNotificationAction._
-    def theSame(a: PublishNotificationAction, b: PublishNotificationAction) =
-      a == b
-
-    (step, requested) match {
-      case (_, ALL) => true
-      case (s, r) if theSame(s, r) => true
-      case (_, _) => false
-    }
-  }
 }
 
 /**

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotification.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotification.scala
@@ -97,7 +97,14 @@ case class PublishNotification(
   datasetId: Int,
   status: PublishStatus, // TODO: remove this and send "success" boolean from step function
   version: Int,
-  error: Option[String] = None
+  error: Option[String] = None,
+  loadResultsFromS3: Option[Boolean] = Some(true),
+  updateDatasetStatus: Option[Boolean] = Some(true),
+  notifyPennsieve: Option[Boolean] = Some(true),
+  publishDoi: Option[Boolean] = Some(true),
+  storeFiles: Option[Boolean] = Some(true),
+  indexDataset: Option[Boolean] = Some(true),
+  runS3Clean: Option[Boolean] = Some(true)
 ) extends SQSNotification
     with JobDoneNotification {
 

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -35,7 +35,6 @@ import com.pennsieve.discover.server.definitions.{
   DatasetPublishStatus,
   InternalContributor
 }
-import com.pennsieve.discover.utils.runSequentially
 import com.pennsieve.discover.{ Authenticator, Ports, UnauthorizedException }
 import com.pennsieve.doi.client.definitions.PublishDoiRequest
 import com.pennsieve.doi.models.{ DoiDTO, DoiState }

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -261,27 +261,15 @@ class SQSNotificationHandler(
       // Read the outputs.json file in S3
       publishResult <- ports.s3StreamClient
         .readPublishJobOutput(version)
+      // Read the metadata (manifest.json) file from S3
       metadata <- ports.s3StreamClient
         .readDatasetMetadata(version)
 
-      _ = {
-        ports.log.info(
-          s"handleSuccess() dataset: ${version.datasetId} version: ${version.version}"
-        )
-        ports.log.info(
-          s"handleSuccess() publishResult: ${publishResult} (${metadata.files.length} files)"
-        )
-      }
-
-      _ = println(
-        s"handleSuccess() dataset: ${version.datasetId} version: ${version.version}"
-      )
-      _ = println(
+      _ = ports.log.info(
         s"handleSuccess() publishResult: ${publishResult} (${metadata.files.length} files)"
       )
 
       // Update the dataset version with the information in outputs.json
-      _ = println(s"handleSuccess() updating result metadata")
       updatedVersion <- ports.db.run(
         PublicDatasetVersionsMapper.setResultMetadata(
           version = version,
@@ -292,17 +280,13 @@ class SQSNotificationHandler(
           changelog = publishResult.changelogKey
         )
       )
-      _ = println(s"handleSuccess() updated result metadata")
 
-      _ = println(s"handleSuccess() notify API")
       _ = ports.log.info("handleSuccess() notify API")
       _ <- ports.pennsieveApiClient
         .putPublishComplete(publishStatus, None)
         .value
         .flatMap(_.fold(Future.failed, Future.successful))
-      _ = println(s"handleSuccess() notified API")
 
-      _ = println(s"handleSuccess() publish DOI")
       _ = ports.log.info("handleSuccess() publish DOI")
       _ <- publishDoi(
         publicDataset,
@@ -311,15 +295,12 @@ class SQSNotificationHandler(
         collections,
         externalPublications
       )
-      _ = println(s"handleSuccess() published DOI")
 
       // Store files in Postgres
-      _ = println(s"handleSuccess() store files")
       _ = ports.log.info("handleSuccess() store files")
       _ <- updatedVersion.migrated match {
         case true =>
           // Publishing 5x
-          println(s"handleSuccess() storing files: Publishing 5x")
           val manifestFile =
             metadata.files.filter(_.path.equals("manifest.json")).head
           val files = manifestFile.copy(
@@ -328,31 +309,26 @@ class SQSNotificationHandler(
 
           updatedVersion.version match {
             case 1 =>
-              println(
-                s"handleSuccess() storing files: Publishing 5x - first publication"
+              publishFirstVersion(updatedVersion, files)(
+                ports.slickSession,
+                logContext
               )
-              publishFirstVersion(updatedVersion, files)(ports.slickSession)
             case _ =>
-              println(
-                s"handleSuccess() storing files: Publishing 5x - subsequent publication"
+              publishNextVersion(updatedVersion, files)(
+                ports.slickSession,
+                logContext
               )
-              publishNextVersionV3(updatedVersion, files)(ports.slickSession)
           }
         case false =>
           // Publishing 4x
-          println(s"handleSuccess() storing files: Publishing 5x")
           ports.db.run(PublicFilesMapper.createMany(version, metadata.files))
       }
-      _ = println(s"handleSuccess() stored files")
 
       // Add dataset to search index
-      _ = println(s"handleSuccess() index dataset")
       _ = ports.log.info("handleSuccess() index dataset")
       _ <- Search.indexDataset(publicDataset, updatedVersion, ports)
-      _ = println(s"handleSuccess() indexed dataset")
 
       // invoke S3 Cleanup Lambda to delete publishing intermediate files
-      _ = println(s"handleSuccess() run S3 clean: TIDY")
       _ = ports.log.info("handleSuccess() run S3 clean: TIDY")
       _ <- ports.lambdaClient.runS3Clean(
         updatedVersion.s3Key.value,
@@ -361,82 +337,16 @@ class SQSNotificationHandler(
         S3CleanupStage.Tidy,
         updatedVersion.migrated
       )
-      _ = println(s"handleSuccess() done")
     } yield ()
 
   private def publishFirstVersion(
     version: PublicDatasetVersion,
     files: List[FileManifest]
   )(implicit
-    slickSession: SlickSession
+    slickSession: SlickSession,
+    logContext: LogContext
   ): Future[Unit] = {
-
-//    implicit val slickSessionCreatedForDbAndProfile: SlickSession =
-//      SlickSession.forDbAndProfile(ports.db, profile)
-
-//    val queryFindAll = for {
-//      allFileVersions <- PublicFileVersionsMapper.getAll(version.datasetId)
-//    } yield (allFileVersions)
-
     for {
-      _ <- Future.successful(
-        println(
-          s"publishFirstVersion() dataset ${version.datasetId} version ${version.version} (${files.length} files)"
-        )
-      )
-
-//      publicDataset <- ports.db.run(
-//        PublicDatasetsMapper.getDataset(version.datasetId)
-//      )
-//      _ = println(s"publishFirstVersion() publicDataset: ${publicDataset}")
-//
-//      publicDatasetVersion <- ports.db.run(
-//        PublicDatasetVersionsMapper
-//          .getVersion(version.datasetId, version.version)
-//      )
-//      _ = println(
-//        s"publishFirstVersion() publicDatasetVersion: ${publicDatasetVersion}"
-//      )
-
-      _ = println(s"publishFirstVersion() creating many file versions")
-      //_ <- ports.db.run(PublicFileVersionsMapper.createMany(version, files))
-
-//      allFileVersions <- Source(files)
-//        .via(
-//          Slick.flowWithPassThrough(
-//            parallelism = 4,
-//            file => PublicFileVersionsMapper.createOne(version, file)
-//          )
-//        )
-//        .runWith(Sink.seq)
-//      _ = println(
-//        s"publishFirstVersion() created ${allFileVersions.length} file versions"
-//      )
-
-      // _ = println(s"publishFirstVersion() finding all file versions")
-      // allFileVersions <- ports.db.run(queryFindAll)
-      // fileIds = allFileVersions.map(_.id).sorted
-      // _ = println(s"publishFirstVersion() fileIds: ${fileIds}")
-//      _ = println(s"publishFirstVersion() storing links")
-//      _ <- ports.db.run(
-//        PublicDatasetVersionFilesTableMapper
-//          .storeLinks(version, allFileVersions)
-//      )
-
-//      allFileVersionLinks <- Source(allFileVersions)
-//        .via(
-//          Slick.flowWithPassThrough(
-//            parallelism = 4,
-//            file =>
-//              PublicDatasetVersionFilesTableMapper
-//                .storeLink(version, file)
-//          )
-//        )
-//        .runWith(Sink.seq)
-//      _ = println(
-//        s"publishFirstVersion() stored ${allFileVersionLinks.length} links"
-//      )
-
       fileVersionLinks <- Source(files)
         .via(
           Slick.flowWithPassThrough(
@@ -453,111 +363,20 @@ class SQSNotificationHandler(
           )
         )
         .runWith(Sink.seq)
-      _ = println(
-        s"publishFirstVersion() created ${fileVersionLinks.length} file versions and links"
+      _ = ports.log.info(
+        s"publishFirstVersion() stored ${fileVersionLinks.length} files and links"
       )
-
     } yield ()
   }
 
   private def publishNextVersion(
     version: PublicDatasetVersion,
     files: List[FileManifest]
-  ): Future[Unit] =
-    for {
-      _ <- Future.successful(
-        println(
-          s"publishNextVersionV() dataset ${version.datasetId} version ${version.version} (${files.length} files"
-        )
-      )
-      _ = println(s"publishNextVersionV() find or create")
-      fileVersions <- Future.sequence(
-        files.map(
-          file =>
-            ports.db.run(PublicFileVersionsMapper.findOrCreate(version, file))
-        )
-      )
-      _ = println(s"publishNextVersionV() store links")
-      _ <- ports.db.run(
-        PublicDatasetVersionFilesTableMapper.storeLinks(version, fileVersions)
-      )
-    } yield ()
-
-  private def publishNextVersionV2(
-    version: PublicDatasetVersion,
-    files: List[FileManifest]
-  ): Future[Unit] = {
-
-    def lookup(
-      file: FileManifest
-    )(implicit
-      version: PublicDatasetVersion
-    ): Future[PublicFileVersion] =
-      ports.db.run(PublicFileVersionsMapper.findOrCreate(version, file))
-    implicit val ver = version
-    for {
-      _ <- Future.successful(
-        println(
-          s"publishNextVersionV2() dataset ${version.datasetId} version ${version.version} (${files.length} files"
-        )
-      )
-      _ = println(s"publishNextVersionV2() lookup: find or create")
-      fileVersions <- runSequentially(files)(lookup)
-      _ = println(s"publishNextVersionV2() store links")
-      _ <- ports.db.run(
-        PublicDatasetVersionFilesTableMapper.storeLinks(version, fileVersions)
-      )
-    } yield ()
-  }
-
-  private def publishNextVersionV3(
-    version: PublicDatasetVersion,
-    files: List[FileManifest]
   )(implicit
-    slickSession: SlickSession
+    slickSession: SlickSession,
+    logContext: LogContext
   ): Future[Unit] = {
-//    val pfvs = files.map(
-//      file =>
-//        PublicFileVersion(
-//          name = file.name,
-//          fileType = file.fileType.toString,
-//          size = file.size,
-//          sourcePackageId = file.sourcePackageId,
-//          sourceFileUUID = None,
-//          s3Key = version.s3Key / file.path,
-//          s3Version = file.s3VersionId.getOrElse("missing"),
-//          path = LTree(
-//            PublicFileVersionsMapper
-//              .convertPathToTree(version.s3Key / file.path)
-//          ),
-//          datasetId = version.datasetId,
-//          sha256 = file.sha256
-//        )
-//    )
-
-//    val insertIfNotExists: Flow[PublicFileVersion, PublicFileVersion, NotUsed] =
-//      Flow[PublicFileVersion].map(
-//        pfv => ports.db.run(PublicFileVersionsMapper.insert(pfv))
-//      )
-
-//    for {
-//      _ <- Source(pfvs)
-//        .mapAsync(1)(pfv => {
-//          ports.db.run(PublicFileVersionsMapper.insert(pfv))
-//        })
-//        .runWith(Sink.seq)
-//
-//    } yield ()
-
     for {
-//      fileIds <- Source(pfvs)
-//        .via(
-//          Slick
-//            .flow(parallelism = 4, pfv => PublicFileVersionsMapper.insert(pfv))
-//        )
-//        .runWith(Sink.seq)
-//      //_ = println(s"publishNextVersionV3() fileIds: ${fileIds.toList.sorted}")
-//      // TODO: link the fileIds to the dataset version
       fileVersionLinks <- Source(files)
         .via(
           Slick.flowWithPassThrough(
@@ -574,10 +393,9 @@ class SQSNotificationHandler(
           )
         )
         .runWith(Sink.seq)
-      _ = println(
-        s"publishNextVersionV3() stored and linked ${fileVersionLinks.length}"
+      _ = ports.log.info(
+        s"publishNextVersion() stored ${fileVersionLinks.length} files and links"
       )
-
     } yield ()
   }
 

--- a/server/src/main/scala/com/pennsieve/discover/utils/package.scala
+++ b/server/src/main/scala/com/pennsieve/discover/utils/package.scala
@@ -4,13 +4,10 @@ package com.pennsieve.discover
 
 import java.time.temporal.ChronoUnit
 
-import com.pennsieve.discover.models.{
-  DatasetDownload,
-  PublicDatasetVersion,
-  S3Key
-}
+import com.pennsieve.discover.models.DatasetDownload
 import com.pennsieve.models._
 import org.apache.commons.lang3.StringUtils
+import scala.concurrent._
 
 package object utils {
 
@@ -86,5 +83,29 @@ package object utils {
           databaseDL
       }.isEmpty
     }
+  }
+
+  /**
+    * Executes asynchronous function on each item in the iterable sequentially (not in parallel)
+    * @param items: the iterable of items
+    * @param f: the asynchronous function that returns a Future
+    * @param ec: ExecutionContext
+    * @tparam T
+    * @tparam U
+    * @return Future with a List of Items
+    * @reference: https://stackoverflow.com/questions/20414500/how-to-do-sequential-execution-of-futures-in-scala
+    */
+  def runSequentially[T, U](
+    items: IterableOnce[T]
+  )(
+    f: T => Future[U]
+  )(implicit
+    ec: ExecutionContext
+  ): Future[List[U]] = {
+    items.iterator.foldLeft(Future.successful[List[U]](Nil)) { (acc, item) =>
+      acc.flatMap { x =>
+        f(item).map(_ :: x)
+      }
+    } map (_.reverse)
   }
 }

--- a/server/src/main/scala/com/pennsieve/discover/utils/package.scala
+++ b/server/src/main/scala/com/pennsieve/discover/utils/package.scala
@@ -7,7 +7,6 @@ import java.time.temporal.ChronoUnit
 import com.pennsieve.discover.models.DatasetDownload
 import com.pennsieve.models._
 import org.apache.commons.lang3.StringUtils
-import scala.concurrent._
 
 package object utils {
 
@@ -85,27 +84,4 @@ package object utils {
     }
   }
 
-  /**
-    * Executes asynchronous function on each item in the iterable sequentially (not in parallel)
-    * @param items: the iterable of items
-    * @param f: the asynchronous function that returns a Future
-    * @param ec: ExecutionContext
-    * @tparam T
-    * @tparam U
-    * @return Future with a List of Items
-    * @reference: https://stackoverflow.com/questions/20414500/how-to-do-sequential-execution-of-futures-in-scala
-    */
-  def runSequentially[T, U](
-    items: IterableOnce[T]
-  )(
-    f: T => Future[U]
-  )(implicit
-    ec: ExecutionContext
-  ): Future[List[U]] = {
-    items.iterator.foldLeft(Future.successful[List[U]](Nil)) { (acc, item) =>
-      acc.flatMap { x =>
-        f(item).map(_ :: x)
-      }
-    } map (_.reverse)
-  }
 }

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -352,6 +352,49 @@ object TestUtilities extends AwaitableImplicits {
       )
       .awaitFinite()
 
+  def assetFiles(): List[FileManifest] = List(
+    FileManifest(
+      name = "banner.jpg",
+      path = "banner.jpg",
+      size = TestUtilities.randomInteger(16 * 1024),
+      fileType = FileType.JPEG,
+      sourcePackageId = None,
+      id = None,
+      s3VersionId = Some(TestUtilities.randomString()),
+      sha256 = Some(TestUtilities.randomString())
+    ),
+    FileManifest(
+      name = "readme.md",
+      path = "readme.md",
+      size = TestUtilities.randomInteger(16 * 1024),
+      fileType = FileType.Markdown,
+      sourcePackageId = None,
+      id = None,
+      s3VersionId = Some(TestUtilities.randomString()),
+      sha256 = Some(TestUtilities.randomString())
+    ),
+    FileManifest(
+      name = "changelog.md",
+      path = "changelog.md",
+      size = TestUtilities.randomInteger(16 * 1024),
+      fileType = FileType.Markdown,
+      sourcePackageId = None,
+      id = None,
+      s3VersionId = Some(TestUtilities.randomString()),
+      sha256 = Some(TestUtilities.randomString())
+    ),
+    FileManifest(
+      name = "manifest.json",
+      path = "manifest.json",
+      size = TestUtilities.randomInteger(16 * 1024),
+      fileType = FileType.Json,
+      sourcePackageId = None,
+      id = None,
+      s3VersionId = Some(TestUtilities.randomString()),
+      sha256 = Some(TestUtilities.randomString())
+    )
+  )
+
   def createDatasetDownloadRow(
     db: Database
   )(

--- a/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
@@ -712,7 +712,7 @@ class SQSNotificationHandlerSpec
 
     "handle large number of files in initial publication" in {
       val numberOfFiles = 10000
-      // create public dataset version 1 with 5000 files
+
       val publicDataset =
         TestUtilities.createDataset(ports.db)()
 
@@ -751,50 +751,7 @@ class SQSNotificationHandlerSpec
         degree = Some(Degree.PhD)
       )
 
-      val assetFiles = List(
-        FileManifest(
-          name = "banner.jpg",
-          path = "banner.jpg",
-          size = TestUtilities.randomInteger(16 * 1024),
-          fileType = FileType.JPEG,
-          sourcePackageId = None,
-          id = None,
-          s3VersionId = Some(TestUtilities.randomString()),
-          sha256 = Some(TestUtilities.randomString())
-        ),
-        FileManifest(
-          name = "readme.md",
-          path = "readme.md",
-          size = TestUtilities.randomInteger(16 * 1024),
-          fileType = FileType.Markdown,
-          sourcePackageId = None,
-          id = None,
-          s3VersionId = Some(TestUtilities.randomString()),
-          sha256 = Some(TestUtilities.randomString())
-        ),
-        FileManifest(
-          name = "changelog.md",
-          path = "changelog.md",
-          size = TestUtilities.randomInteger(16 * 1024),
-          fileType = FileType.Markdown,
-          sourcePackageId = None,
-          id = None,
-          s3VersionId = Some(TestUtilities.randomString()),
-          sha256 = Some(TestUtilities.randomString())
-        ),
-        FileManifest(
-          name = "manifest.json",
-          path = "manifest.json",
-          size = TestUtilities.randomInteger(16 * 1024),
-          fileType = FileType.Json,
-          sourcePackageId = None,
-          id = None,
-          s3VersionId = Some(TestUtilities.randomString()),
-          sha256 = Some(TestUtilities.randomString())
-        )
-      )
-
-      // generate manifest.json with 5000 files
+      // generate dataset metadata (manifest.json)
       val metadata = DatasetMetadataV4_0(
         pennsieveDatasetId = publicDataset.id,
         version = publicDatasetV1.version,
@@ -814,7 +771,7 @@ class SQSNotificationHandlerSpec
         schemaVersion = "n/a",
         collections = None,
         relatedPublications = None,
-        files = assetFiles ++ (1 to numberOfFiles).map { i =>
+        files = TestUtilities.assetFiles() ++ (1 to numberOfFiles).map { i =>
           val name = s"test-file-${i}.csv"
           FileManifest(
             name = name,
@@ -850,7 +807,6 @@ class SQSNotificationHandlerSpec
       val numberOfFilesV1 = 10000
       val numberOfFilesV2 = 10000
 
-      // create public dataset version 1 with 5000 files
       val publicDataset =
         TestUtilities.createDataset(ports.db)()
 
@@ -889,51 +845,7 @@ class SQSNotificationHandlerSpec
         degree = Some(Degree.PhD)
       )
 
-      val assetFiles = List(
-        FileManifest(
-          name = "banner.jpg",
-          path = "banner.jpg",
-          size = TestUtilities.randomInteger(16 * 1024),
-          fileType = FileType.JPEG,
-          sourcePackageId = None,
-          id = None,
-          s3VersionId = Some(TestUtilities.randomString()),
-          sha256 = Some(TestUtilities.randomString())
-        ),
-        FileManifest(
-          name = "readme.md",
-          path = "readme.md",
-          size = TestUtilities.randomInteger(16 * 1024),
-          fileType = FileType.Markdown,
-          sourcePackageId = None,
-          id = None,
-          s3VersionId = Some(TestUtilities.randomString()),
-          sha256 = Some(TestUtilities.randomString())
-        ),
-        FileManifest(
-          name = "changelog.md",
-          path = "changelog.md",
-          size = TestUtilities.randomInteger(16 * 1024),
-          fileType = FileType.Markdown,
-          sourcePackageId = None,
-          id = None,
-          s3VersionId = Some(TestUtilities.randomString()),
-          sha256 = Some(TestUtilities.randomString())
-        ),
-        FileManifest(
-          name = "manifest.json",
-          path = "manifest.json",
-          size = TestUtilities.randomInteger(16 * 1024),
-          fileType = FileType.Json,
-          sourcePackageId = None,
-          id = None,
-          s3VersionId = Some(TestUtilities.randomString()),
-          sha256 = Some(TestUtilities.randomString())
-        )
-      )
-
-      // generate manifest.json with 5000 files
-
+      // generate list of files in V1 of dataset
       val v1Files = (1 to numberOfFilesV1).map { i =>
         val name = s"test-file-${i}.csv"
         FileManifest(
@@ -947,6 +859,8 @@ class SQSNotificationHandlerSpec
           sha256 = Some(TestUtilities.randomString())
         )
       }.toList
+
+      // generate dataset V1 metadata (manifest.json)
       val metadataV1 = DatasetMetadataV4_0(
         pennsieveDatasetId = publicDataset.id,
         version = publicDatasetV1.version,
@@ -966,7 +880,7 @@ class SQSNotificationHandlerSpec
         schemaVersion = "n/a",
         collections = None,
         relatedPublications = None,
-        files = assetFiles ++ v1Files,
+        files = TestUtilities.assetFiles() ++ v1Files,
         pennsieveSchemaVersion = "4.0"
       )
 
@@ -1012,7 +926,7 @@ class SQSNotificationHandlerSpec
           )
         )
 
-      // generate manifest.json with 5000 files
+      // generate list of files in V2 of dataset
       val v2Files = (1 to numberOfFilesV2).map { i =>
         val name = s"test-file-${i}.csv"
         FileManifest(
@@ -1026,6 +940,8 @@ class SQSNotificationHandlerSpec
           sha256 = Some(TestUtilities.randomString())
         )
       }.toList
+
+      // generate dataset V2 metadata (manifest.json)
       val metadataV2 = DatasetMetadataV4_0(
         pennsieveDatasetId = publicDataset.id,
         version = publicDatasetV1.version,
@@ -1045,7 +961,7 @@ class SQSNotificationHandlerSpec
         schemaVersion = "n/a",
         collections = None,
         relatedPublications = None,
-        files = assetFiles ++ v1Files ++ v2Files,
+        files = TestUtilities.assetFiles() ++ v1Files ++ v2Files,
         pennsieveSchemaVersion = "4.0"
       )
 
@@ -1064,143 +980,6 @@ class SQSNotificationHandlerSpec
       ) shouldBe an[MessageAction.Delete]
 
     }
-
-//    "handle 1 million files in publication" in {
-//      val numberOfFiles = 1000000
-//      // create public dataset version 1 with 5000 files
-//      val publicDataset =
-//        TestUtilities.createDataset(ports.db)()
-//
-//      val doi = ports.doiClient
-//        .asInstanceOf[MockDoiClient]
-//        .createMockDoi(
-//          publicDataset.sourceOrganizationId,
-//          publicDataset.sourceDatasetId
-//        )
-//
-//      val publicDatasetV1 = TestUtilities.createNewDatasetVersion(ports.db)(
-//        id = publicDataset.id,
-//        status = PublishStatus.PublishInProgress,
-//        doi = doi.doi,
-//        migrated = true
-//      )
-//
-//      // Successful publish jobs create an outputs.json file
-//      ports.s3StreamClient
-//        .asInstanceOf[MockS3StreamClient]
-//        .withNextPublishResult(
-//          publicDatasetV1.s3Key,
-//          PublishJobOutput(
-//            readmeKey = publicDatasetV1.s3Key / "readme.md",
-//            bannerKey = publicDatasetV1.s3Key / "banner.jpg",
-//            changelogKey = publicDatasetV1.s3Key / "changelog.md",
-//            totalSize = 76543
-//          )
-//        )
-//
-//      val datasetContributor = PublishedContributor(
-//        first_name = "dataset",
-//        last_name = "owner",
-//        orcid = Some("0000-0001-0023-9087"),
-//        middle_initial = None,
-//        degree = Some(Degree.PhD)
-//      )
-//
-//      val assetFiles = List(
-//        FileManifest(
-//          name = "banner.jpg",
-//          path = "banner.jpg",
-//          size = TestUtilities.randomInteger(16 * 1024),
-//          fileType = FileType.JPEG,
-//          sourcePackageId = None,
-//          id = None,
-//          s3VersionId = Some(TestUtilities.randomString()),
-//          sha256 = Some(TestUtilities.randomString())
-//        ),
-//        FileManifest(
-//          name = "readme.md",
-//          path = "readme.md",
-//          size = TestUtilities.randomInteger(16 * 1024),
-//          fileType = FileType.Markdown,
-//          sourcePackageId = None,
-//          id = None,
-//          s3VersionId = Some(TestUtilities.randomString()),
-//          sha256 = Some(TestUtilities.randomString())
-//        ),
-//        FileManifest(
-//          name = "changelog.md",
-//          path = "changelog.md",
-//          size = TestUtilities.randomInteger(16 * 1024),
-//          fileType = FileType.Markdown,
-//          sourcePackageId = None,
-//          id = None,
-//          s3VersionId = Some(TestUtilities.randomString()),
-//          sha256 = Some(TestUtilities.randomString())
-//        ),
-//        FileManifest(
-//          name = "manifest.json",
-//          path = "manifest.json",
-//          size = TestUtilities.randomInteger(16 * 1024),
-//          fileType = FileType.Json,
-//          sourcePackageId = None,
-//          id = None,
-//          s3VersionId = Some(TestUtilities.randomString()),
-//          sha256 = Some(TestUtilities.randomString())
-//        )
-//      )
-//
-//      // generate manifest.json with 5000 files
-//      val metadata = DatasetMetadataV4_0(
-//        pennsieveDatasetId = publicDataset.id,
-//        version = publicDatasetV1.version,
-//        revision = None,
-//        name = publicDataset.name,
-//        description = publicDatasetV1.description,
-//        creator = datasetContributor,
-//        contributors = List(datasetContributor),
-//        sourceOrganization = "1",
-//        keywords = List("data"),
-//        datePublished = LocalDate.now(),
-//        license = Some(License.`Community Data License Agreement – Permissive`),
-//        `@id` = doi.doi,
-//        publisher = "Pennsieve",
-//        `@context` = "public data",
-//        `@type` = "dataset",
-//        schemaVersion = "n/a",
-//        collections = None,
-//        relatedPublications = None,
-//        files = assetFiles ++ (1 to numberOfFiles).map { i =>
-//          val name = s"test-file-${i}.csv"
-//          FileManifest(
-//            name = name,
-//            path = s"data/${name}",
-//            size = TestUtilities.randomInteger(16 * 1024),
-//            fileType = FileType.CSV,
-//            sourcePackageId = Some(s"N:package:${UUID.randomUUID().toString}"),
-//            id = None,
-//            s3VersionId = Some(TestUtilities.randomString()),
-//            sha256 = Some(TestUtilities.randomString())
-//          )
-//        }.toList,
-//        pennsieveSchemaVersion = "4.0"
-//      )
-//
-//      ports.s3StreamClient
-//        .asInstanceOf[MockS3StreamClient]
-//        .withNextPublishMetadata(publicDatasetV1.s3Key, metadata)
-//
-//      processNotification(
-//        PublishNotification(
-//          publicDataset.sourceOrganizationId,
-//          publicDataset.sourceDatasetId,
-//          PublishStatus.PublishSucceeded,
-//          publicDatasetV1.version
-//        ),
-//        waitTime = 300.seconds
-//      ) shouldBe an[MessageAction.Delete]
-//
-//    }
-
   }
 
 }

--- a/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
@@ -6,7 +6,15 @@ import akka.actor.ActorSystem
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.stream.alpakka.sqs.MessageAction
 import com.pennsieve.discover.ServiceSpecHarness
-import com.pennsieve.models.{ FileType, PublishStatus }
+import com.pennsieve.models.{
+  DatasetMetadataV4_0,
+  Degree,
+  FileManifest,
+  FileType,
+  License,
+  PublishStatus,
+  PublishedContributor
+}
 import com.pennsieve.models.DatasetMetadata._
 import com.pennsieve.discover.db.profile.api._
 import com.pennsieve.discover.clients.{
@@ -42,7 +50,7 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.time.LocalDate
-import java.util.Calendar
+import java.util.{ Calendar, UUID }
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
@@ -698,6 +706,359 @@ class SQSNotificationHandlerSpec
       ) shouldBe an[MessageAction.Delete]
 
     }
+
+    "handle large number of files in initial publication" in {
+      val numberOfFiles = 10000
+      // create public dataset version 1 with 5000 files
+      val publicDataset =
+        TestUtilities.createDataset(ports.db)()
+
+      val doi = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .createMockDoi(
+          publicDataset.sourceOrganizationId,
+          publicDataset.sourceDatasetId
+        )
+
+      val publicDatasetV1 = TestUtilities.createNewDatasetVersion(ports.db)(
+        id = publicDataset.id,
+        status = PublishStatus.PublishInProgress,
+        doi = doi.doi,
+        migrated = true
+      )
+
+      // Successful publish jobs create an outputs.json file
+      ports.s3StreamClient
+        .asInstanceOf[MockS3StreamClient]
+        .withNextPublishResult(
+          publicDatasetV1.s3Key,
+          PublishJobOutput(
+            readmeKey = publicDatasetV1.s3Key / "readme.md",
+            bannerKey = publicDatasetV1.s3Key / "banner.jpg",
+            changelogKey = publicDatasetV1.s3Key / "changelog.md",
+            totalSize = 76543
+          )
+        )
+
+      val datasetContributor = PublishedContributor(
+        first_name = "dataset",
+        last_name = "owner",
+        orcid = Some("0000-0001-0023-9087"),
+        middle_initial = None,
+        degree = Some(Degree.PhD)
+      )
+
+      val assetFiles = List(
+        FileManifest(
+          name = "banner.jpg",
+          path = "banner.jpg",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.JPEG,
+          sourcePackageId = None,
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        ),
+        FileManifest(
+          name = "readme.md",
+          path = "readme.md",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.Markdown,
+          sourcePackageId = None,
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        ),
+        FileManifest(
+          name = "changelog.md",
+          path = "changelog.md",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.Markdown,
+          sourcePackageId = None,
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        ),
+        FileManifest(
+          name = "manifest.json",
+          path = "manifest.json",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.Json,
+          sourcePackageId = None,
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        )
+      )
+
+      // generate manifest.json with 5000 files
+      val metadata = DatasetMetadataV4_0(
+        pennsieveDatasetId = publicDataset.id,
+        version = publicDatasetV1.version,
+        revision = None,
+        name = publicDataset.name,
+        description = publicDatasetV1.description,
+        creator = datasetContributor,
+        contributors = List(datasetContributor),
+        sourceOrganization = "1",
+        keywords = List("data"),
+        datePublished = LocalDate.now(),
+        license = Some(License.`Community Data License Agreement – Permissive`),
+        `@id` = doi.doi,
+        publisher = "Pennsieve",
+        `@context` = "public data",
+        `@type` = "dataset",
+        schemaVersion = "n/a",
+        collections = None,
+        relatedPublications = None,
+        files = assetFiles ++ (1 to numberOfFiles).map { i =>
+          val name = s"test-file-${i}.csv"
+          FileManifest(
+            name = name,
+            path = s"data/${name}",
+            size = TestUtilities.randomInteger(16 * 1024),
+            fileType = FileType.CSV,
+            sourcePackageId = Some(s"N:package:${UUID.randomUUID().toString}"),
+            id = None,
+            s3VersionId = Some(TestUtilities.randomString()),
+            sha256 = Some(TestUtilities.randomString())
+          )
+        }.toList,
+        pennsieveSchemaVersion = "4.0"
+      )
+
+      ports.s3StreamClient
+        .asInstanceOf[MockS3StreamClient]
+        .withNextPublishMetadata(publicDatasetV1.s3Key, metadata)
+
+      processNotification(
+        PublishNotification(
+          publicDataset.sourceOrganizationId,
+          publicDataset.sourceDatasetId,
+          PublishStatus.PublishSucceeded,
+          publicDatasetV1.version
+        )
+      ) shouldBe an[MessageAction.Delete]
+
+    }
+
+    "handle large number of files in subsequent publication" in {
+      val numberOfFilesV1 = 5000
+      val numberOfFilesV2 = 5000
+
+      // create public dataset version 1 with 5000 files
+      val publicDataset =
+        TestUtilities.createDataset(ports.db)()
+
+      val doi = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .createMockDoi(
+          publicDataset.sourceOrganizationId,
+          publicDataset.sourceDatasetId
+        )
+
+      val publicDatasetV1 = TestUtilities.createNewDatasetVersion(ports.db)(
+        id = publicDataset.id,
+        status = PublishStatus.PublishInProgress,
+        doi = doi.doi,
+        migrated = true
+      )
+
+      // Successful publish jobs create an outputs.json file
+      ports.s3StreamClient
+        .asInstanceOf[MockS3StreamClient]
+        .withNextPublishResult(
+          publicDatasetV1.s3Key,
+          PublishJobOutput(
+            readmeKey = publicDatasetV1.s3Key / "readme.md",
+            bannerKey = publicDatasetV1.s3Key / "banner.jpg",
+            changelogKey = publicDatasetV1.s3Key / "changelog.md",
+            totalSize = 76543
+          )
+        )
+
+      val datasetContributor = PublishedContributor(
+        first_name = "dataset",
+        last_name = "owner",
+        orcid = Some("0000-0001-0023-9087"),
+        middle_initial = None,
+        degree = Some(Degree.PhD)
+      )
+
+      val assetFiles = List(
+        FileManifest(
+          name = "banner.jpg",
+          path = "banner.jpg",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.JPEG,
+          sourcePackageId = None,
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        ),
+        FileManifest(
+          name = "readme.md",
+          path = "readme.md",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.Markdown,
+          sourcePackageId = None,
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        ),
+        FileManifest(
+          name = "changelog.md",
+          path = "changelog.md",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.Markdown,
+          sourcePackageId = None,
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        ),
+        FileManifest(
+          name = "manifest.json",
+          path = "manifest.json",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.Json,
+          sourcePackageId = None,
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        )
+      )
+
+      // generate manifest.json with 5000 files
+
+      val v1Files = (1 to numberOfFilesV1).map { i =>
+        val name = s"test-file-${i}.csv"
+        FileManifest(
+          name = name,
+          path = s"data/${name}",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.CSV,
+          sourcePackageId = Some(s"N:package:${UUID.randomUUID().toString}"),
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        )
+      }.toList
+      val metadataV1 = DatasetMetadataV4_0(
+        pennsieveDatasetId = publicDataset.id,
+        version = publicDatasetV1.version,
+        revision = None,
+        name = publicDataset.name,
+        description = publicDatasetV1.description,
+        creator = datasetContributor,
+        contributors = List(datasetContributor),
+        sourceOrganization = "1",
+        keywords = List("data"),
+        datePublished = LocalDate.now(),
+        license = Some(License.`Community Data License Agreement – Permissive`),
+        `@id` = doi.doi,
+        publisher = "Pennsieve",
+        `@context` = "public data",
+        `@type` = "dataset",
+        schemaVersion = "n/a",
+        collections = None,
+        relatedPublications = None,
+        files = assetFiles ++ v1Files,
+        pennsieveSchemaVersion = "4.0"
+      )
+
+      ports.s3StreamClient
+        .asInstanceOf[MockS3StreamClient]
+        .withNextPublishMetadata(publicDatasetV1.s3Key, metadataV1)
+
+      processNotification(
+        PublishNotification(
+          publicDataset.sourceOrganizationId,
+          publicDataset.sourceDatasetId,
+          PublishStatus.PublishSucceeded,
+          publicDatasetV1.version
+        )
+      ) shouldBe an[MessageAction.Delete]
+
+      // create version 2
+      val doiV2 = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .createMockDoi(
+          publicDataset.sourceOrganizationId,
+          publicDataset.sourceDatasetId
+        )
+
+      val publicDatasetV2 = TestUtilities.createNewDatasetVersion(ports.db)(
+        id = publicDataset.id,
+        status = PublishStatus.PublishInProgress,
+        doi = doiV2.doi,
+        migrated = true
+      )
+
+      // Successful publish jobs create an outputs.json file
+      ports.s3StreamClient
+        .asInstanceOf[MockS3StreamClient]
+        .withNextPublishResult(
+          publicDatasetV2.s3Key,
+          PublishJobOutput(
+            readmeKey = publicDatasetV1.s3Key / "readme.md",
+            bannerKey = publicDatasetV1.s3Key / "banner.jpg",
+            changelogKey = publicDatasetV1.s3Key / "changelog.md",
+            totalSize = 76543
+          )
+        )
+
+      // generate manifest.json with 5000 files
+      val v2Files = (1 to numberOfFilesV2).map { i =>
+        val name = s"test-file-${i}.csv"
+        FileManifest(
+          name = name,
+          path = s"data/${name}",
+          size = TestUtilities.randomInteger(16 * 1024),
+          fileType = FileType.CSV,
+          sourcePackageId = Some(s"N:package:${UUID.randomUUID().toString}"),
+          id = None,
+          s3VersionId = Some(TestUtilities.randomString()),
+          sha256 = Some(TestUtilities.randomString())
+        )
+      }.toList
+      val metadataV2 = DatasetMetadataV4_0(
+        pennsieveDatasetId = publicDataset.id,
+        version = publicDatasetV1.version,
+        revision = None,
+        name = publicDataset.name,
+        description = publicDatasetV1.description,
+        creator = datasetContributor,
+        contributors = List(datasetContributor),
+        sourceOrganization = "1",
+        keywords = List("data"),
+        datePublished = LocalDate.now(),
+        license = Some(License.`Community Data License Agreement – Permissive`),
+        `@id` = doiV2.doi,
+        publisher = "Pennsieve",
+        `@context` = "public data",
+        `@type` = "dataset",
+        schemaVersion = "n/a",
+        collections = None,
+        relatedPublications = None,
+        files = assetFiles ++ v1Files ++ v2Files,
+        pennsieveSchemaVersion = "4.0"
+      )
+
+      ports.s3StreamClient
+        .asInstanceOf[MockS3StreamClient]
+        .withNextPublishMetadata(publicDatasetV2.s3Key, metadataV2)
+
+      processNotification(
+        PublishNotification(
+          publicDataset.sourceOrganizationId,
+          publicDataset.sourceDatasetId,
+          PublishStatus.PublishSucceeded,
+          publicDatasetV2.version
+        )
+      ) shouldBe an[MessageAction.Delete]
+
+    }
+
   }
 
 }


### PR DESCRIPTION
Addresses issue of publishing datasets with large number of files. 

`publishNextVersion()` was calling `PublicFileVersionsMapper.findOrCreate()` for every file in the manifest, and accumulating the results with `Future.sequence()`. With this, every request was submitted in a **Future** simultaneously. At some point, the database began rejecting requests and the `RejectedExecutionException` exception was raised. 

This collections of code changes introduces processing of the manifest files using Akka Streams with a Slick Flow component. This provides an execution of the lookup/store and accumulate results steps in a streaming fashion with back pressure at each stage which should prevent overwhelming the database driver with too many simultaneous requests.