### PR TITLE
Fix/publishing finalize with many files

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionFilesTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionFilesTable.scala
@@ -86,6 +86,17 @@ object PublicDatasetVersionFilesTableMapper
       .map(_ => Done)
       .transactionally
 
+  def getLinks(
+    datasetId: Int,
+    versionId: Int
+  )(implicit
+    executionContext: ExecutionContext
+  ): DBIOAction[Seq[PublicDatasetVersionFile], NoStream, Effect.Read with Effect] =
+    this
+      .filter(_.datasetId === datasetId)
+      .filter(_.datasetVersion === versionId)
+      .result
+
   def buildDatasetVersionFile(
     version: PublicDatasetVersion,
     file: PublicFileVersion

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -120,6 +120,21 @@ class SQSNotificationHandler(
           _ <- Search.indexDataset(dataset, version, ports, overwrite = true)
         } yield MessageAction.Delete(sqsMessage)
 
+      case Right(message: PushDoiRequest) =>
+        ports.logger.noContext
+          .info(s"[NOT-YET-SUPPORTED] PushDoiRequest ${message}")
+        Future.successful(MessageAction.Delete(sqsMessage))
+
+      case Right(message: NotifyApiRequest) =>
+        ports.logger.noContext
+          .info(s"[NOT-YET-SUPPORTED] NotifyApiRequest ${message}")
+        Future.successful(MessageAction.Delete(sqsMessage))
+
+      case Right(message: StoreFilesRequest) =>
+        ports.logger.noContext
+          .info(s"[NOT-YET-SUPPORTED] StoreFilesRequest ${message}")
+        Future.successful(MessageAction.Delete(sqsMessage))
+
       case Right(message: JobDoneNotification) =>
         implicit val logContext: LogContext =
           DiscoverLogContext(
@@ -280,6 +295,7 @@ class SQSNotificationHandler(
         )
       )
 
+      // TODO: move notification to the end of this function
       _ = ports.log.info("handleSuccess() notify API")
       _ <- ports.pennsieveApiClient
         .putPublishComplete(publishStatus, None)


### PR DESCRIPTION
- prevent storing duplicate links when finalizing a dataset publication
- framework for supporting single-task final-step actions