### PR TITLE
Feature/publishing datasets of type release (part 1)

### DIFF
--- a/openapi/discover-service-internal.yml
+++ b/openapi/discover-service-internal.yml
@@ -465,6 +465,63 @@ paths:
               schema:
                 type: string
 
+  "/organizations/{organizationId}/release/{datasetId}/publish":
+    post:
+      summary: publish a release to Discover
+      security:
+        - Bearer: []
+      operationId: publish
+      x-scala-package: release
+      parameters:
+        - name: organizationId
+          in: path
+          description: organization id
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: datasetId
+          in: path
+          description: dataset id
+          required: true
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PublishReleaseRequest"
+        description: dataset metadata
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DatasetPublishStatus"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                type: string
+
   "/metrics/dataset/athena/download/sync":
     get:
       security: []
@@ -669,6 +726,105 @@ components:
         readmePresignedUrl:
           type: string
         changelogPresignedUrl:
+          type: string
+
+    PublishReleaseRequest:
+      type: object
+      required:
+        - name
+        - description
+        - ownerId
+        - modelCount
+        - recordCount
+        - fileCount
+        - size
+        - license
+        - contributors
+        - tags
+        - origin
+        - label
+        - marker
+        - repoUrl
+        - ownerNodeId
+        - ownerFirstName
+        - ownerLastName
+        - ownerOrcid
+        - organizationNodeId
+        - organizationName
+        - datasetNodeId
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        ownerId:
+          type: integer
+          format: int32
+        modelCount:
+          type: array
+          items:
+            $ref: ./discover-service.yml#/components/schemas/ModelCount
+        recordCount:
+          type: integer
+          format: int64
+        fileCount:
+          type: integer
+          format: int64
+        size:
+          type: integer
+          format: int64
+        license:
+          type: string
+          x-scala-type: com.pennsieve.models.License
+        contributors:
+          type: array
+          items:
+            $ref: "#/components/schemas/InternalContributor"
+        collections:
+          type: array
+          items:
+            $ref: "#/components/schemas/InternalCollection"
+        externalPublications:
+          type: array
+          items:
+            $ref: "#/components/schemas/InternalExternalPublication"
+        tags:
+          type: array
+          items:
+            type: string
+        ownerNodeId:
+          type: string
+        ownerFirstName:
+          type: string
+        ownerLastName:
+          type: string
+        ownerOrcid:
+          type: string
+        organizationNodeId:
+          type: string
+        organizationName:
+          type: string
+        datasetNodeId:
+          type: string
+        bucketConfig:
+          description: The owning organization's custom bucket config. Omit if there is no such config
+          $ref: "#/components/schemas/BucketConfig"
+        workflowId:
+          type: integer
+          format: int64
+        origin:
+          type: string
+        label:
+          type: string
+        marker:
+          type: string
+        repoUrl:
+          type: string
+        labelUrl:
+          type: string
+        markerUrl:
+          type: string
+        releaseStatus:
           type: string
 
     DatasetPublishStatus:

--- a/openapi/discover-service-internal.yml
+++ b/openapi/discover-service-internal.yml
@@ -470,7 +470,7 @@ paths:
       summary: publish a release to Discover
       security:
         - Bearer: []
-      operationId: publish
+      operationId: publishRelease
       x-scala-package: release
       parameters:
         - name: organizationId

--- a/server/src/main/resources/db/migration/V20240725134200__add_tables_to_support_releases.sql
+++ b/server/src/main/resources/db/migration/V20240725134200__add_tables_to_support_releases.sql
@@ -23,6 +23,7 @@ CREATE TABLE public_dataset_release (
     asset_file_id INT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(dataset_id, dataset_version),
     CONSTRAINT public_dataset_release_fk1
         FOREIGN KEY (dataset_id, dataset_version)
         REFERENCES public_dataset_versions(dataset_id, version)

--- a/server/src/main/resources/db/migration/V20240725134200__add_tables_to_support_releases.sql
+++ b/server/src/main/resources/db/migration/V20240725134200__add_tables_to_support_releases.sql
@@ -1,0 +1,64 @@
+/*
+** Add a "type" column to the Public Datasets tablet to distinguish the kind of
+** dataset being published.
+*/
+ALTER TABLE public_datasets ADD COLUMN dataset_type TEXT NOT NULL DEFAULT 'research';
+
+/*
+** Public Dataset Release
+**   This table holds the details of a Release.
+*/
+CREATE TABLE public_dataset_release (
+    id SERIAL PRIMARY KEY,
+    dataset_id INT NOT NULL,
+    dataset_version INT NOT NULL,
+    origin TEXT NOT NULL,
+    label TEXT NOT NULL,
+    marker TEXT NOT NULL,
+    repo_url TEXT NOT NULL,
+    label_url TEXT,
+    marker_url TEXT,
+    release_status TEXT,
+    asset_file_prefix TEXT,
+    asset_file_id INT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT public_dataset_release_fk1
+        FOREIGN KEY (dataset_id, dataset_version)
+        REFERENCES public_dataset_versions(dataset_id, version)
+        ON DELETE CASCADE
+);
+
+CREATE TRIGGER public_dataset_release_updated_at
+    BEFORE UPDATE ON public_dataset_release
+    FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+/*
+** Public Dataset Release Assets
+**   This table holds the file listing of the release asset (Zip file).
+*/
+CREATE TABLE public_dataset_release_assets (
+    id SERIAL PRIMARY KEY,
+    dataset_id INT NOT NULL,
+    dataset_version INT NOT NULL,
+    release_id INT NOT NULL,
+    file TEXT NOT NULL,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    size INT NOT NULL,
+    path ltree NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT public_dataset_release_assets_fk1
+        FOREIGN KEY (dataset_id, dataset_version)
+            REFERENCES public_dataset_versions(dataset_id, version)
+            ON DELETE CASCADE,
+    CONSTRAINT public_dataset_release_assets_fk2
+        FOREIGN KEY (release_id)
+            REFERENCES public_dataset_release(id)
+            ON DELETE CASCADE
+);
+
+CREATE TRIGGER public_dataset_release_assets_updated_at
+    BEFORE UPDATE ON public_dataset_release_assets
+    FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();

--- a/server/src/main/scala/com/pennsieve/discover/Server.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Server.scala
@@ -88,7 +88,8 @@ object Server extends App with StrictLogging {
         SearchHandler.routes(ports),
         DatasetHandler.routes(ports),
         OrganizationHandler.routes(ports),
-        FileHandler.routes(ports)
+        FileHandler.routes(ports),
+        ReleaseHandler.routes(ports)
       )
     )
 

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseAssetsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseAssetsTable.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.db
+
+import com.github.tminglei.slickpg.LTree
+import com.pennsieve.discover.db.profile.api._
+import com.pennsieve.discover.models.PublicDatasetReleaseAsset
+
+import java.time.OffsetDateTime
+
+class PublicDatasetReleaseAssetsTable(tag: Tag)
+    extends Table[PublicDatasetReleaseAsset](
+      tag,
+      "public_dataset_release_assets"
+    ) {
+
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def datasetId = column[Int]("dataset_id")
+  def datasetVersion = column[Int]("dataset_version")
+  def releaseId = column[Int]("release_id")
+  def file = column[String]("file")
+  def name = column[String]("name")
+  def `type` = column[String]("type")
+  def size = column[Long]("size")
+  def path = column[LTree]("path")
+  def createdAt = column[OffsetDateTime]("created_at")
+  def updatedAt = column[OffsetDateTime]("updated_at")
+
+  def * =
+    (
+      id,
+      datasetId,
+      datasetVersion,
+      releaseId,
+      file,
+      name,
+      `type`,
+      size,
+      path,
+      createdAt,
+      updatedAt
+    ).mapTo[PublicDatasetReleaseAsset]
+
+}
+
+object PublicDatasetReleaseAssetMapper
+    extends TableQuery(new PublicDatasetReleaseAssetsTable(_)) {}

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseTable.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.db
+
+import com.pennsieve.discover.db.profile.api._
+import com.pennsieve.discover.models.PublicDatasetRelease
+
+import java.time.OffsetDateTime
+
+final class PublicDatasetReleaseTable(tag: Tag)
+    extends Table[PublicDatasetRelease](tag, "public_dataset_release") {
+
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def datasetId = column[Int]("dataset_id")
+  def datasetVersion = column[Int]("dataset_version")
+  def origin = column[String]("origin")
+  def label = column[String]("label")
+  def marker = column[String]("marker")
+  def repoUrl = column[String]("repo_url")
+  def labelUrl = column[Option[String]]("label_url")
+  def markerUrl = column[Option[String]]("marker_url")
+  def releaseStatus = column[Option[String]]("release_status")
+  def assetFilePrefix = column[Option[String]]("asset_file_prefix")
+  def assetFileId = column[Option[Int]]("asset_file_id")
+  def createdAt = column[OffsetDateTime]("created_at")
+  def updatedAt = column[OffsetDateTime]("updated_at")
+
+  def * =
+    (
+      id,
+      datasetId,
+      datasetVersion,
+      origin,
+      label,
+      marker,
+      repoUrl,
+      labelUrl,
+      markerUrl,
+      releaseStatus,
+      assetFilePrefix,
+      assetFileId,
+      createdAt,
+      updatedAt
+    ).mapTo[PublicDatasetRelease]
+}
+
+object PublicDatasetReleaseMapper
+    extends TableQuery(new PublicDatasetReleaseTable(_)) {}

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseTable.scala
@@ -4,6 +4,8 @@ package com.pennsieve.discover.db
 
 import com.pennsieve.discover.db.profile.api._
 import com.pennsieve.discover.models.PublicDatasetRelease
+import slick.dbio.Effect
+import slick.sql.FixedSqlAction
 
 import java.time.OffsetDateTime
 import scala.concurrent.ExecutionContext
@@ -103,4 +105,14 @@ object PublicDatasetReleaseMapper
       .result
       .headOption
 
+  def delete(
+    datasetId: Int,
+    versionId: Int
+  )(implicit
+    executionContext: ExecutionContext
+  ): FixedSqlAction[Int, NoStream, Effect.Write] =
+    this
+      .filter(_.datasetId === datasetId)
+      .filter(_.datasetVersion === versionId)
+      .delete
 }

--- a/server/src/main/scala/com/pennsieve/discover/handlers/ReleaseHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/ReleaseHandler.scala
@@ -1,0 +1,206 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.handlers
+
+import akka.actor.ActorSystem
+import com.pennsieve.auth.middleware.Jwt
+import com.pennsieve.discover.utils.getOrCreateDoi
+import com.pennsieve.discover.Authenticator.withServiceOwnerAuthorization
+import com.pennsieve.discover.db.{
+  PublicCollectionsMapper,
+  PublicContributorsMapper,
+  PublicDatasetVersionsMapper,
+  PublicDatasetsMapper,
+  PublicExternalPublicationsMapper
+}
+import com.pennsieve.discover.db.profile.api._
+import com.pennsieve.discover.logging.DiscoverLogContext
+import com.pennsieve.discover.models.{ PennsieveSchemaVersion }
+import com.pennsieve.discover.{
+  Config,
+  DoiCreationException,
+  DoiServiceException,
+  DuplicateDoiException,
+  ForbiddenException,
+  MissingParameterException,
+  Ports,
+  PublishJobException,
+  UnauthorizedException
+}
+import com.pennsieve.discover.server.release.{
+  ReleaseHandler => GuardrailHandler,
+  ReleaseResource => GuardrailResource
+}
+import com.pennsieve.discover.server.definitions
+import com.pennsieve.discover.utils.BucketResolver
+import com.pennsieve.models.{ PublishStatus, RelationshipType }
+import io.circe.DecodingFailure
+import slick.dbio.DBIO
+import slick.jdbc.TransactionIsolation
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.control.NonFatal
+
+class ReleaseHandler(
+  ports: Ports,
+  claim: Jwt.Claim
+)(implicit
+  system: ActorSystem,
+  executionContext: ExecutionContext
+) extends GuardrailHandler {
+  type PublishResponse = GuardrailResource.PublishResponse
+
+  implicit val config: Config = ports.config
+
+  override def publish(
+    respond: GuardrailResource.PublishResponse.type
+  )(
+    organizationId: Int,
+    datasetId: Int,
+    body: definitions.PublishReleaseRequest
+  ): Future[PublishResponse] = {
+    implicit val logContext: DiscoverLogContext = DiscoverLogContext(
+      organizationId = Some(organizationId),
+      datasetId = Some(datasetId),
+      userId = Some(body.ownerId),
+      releaseOrigin = Some(body.origin),
+      releaseRepoUrl = Some(body.repoUrl),
+      releaseLabel = Some(body.label)
+    )
+    ports.log.info("publish release starting")
+    val bucketResolver = BucketResolver(ports)
+    val (targetS3Bucket, _) =
+      bucketResolver.resolveBucketConfig(body.bucketConfig, body.workflowId)
+
+    withServiceOwnerAuthorization[PublishResponse](
+      claim,
+      organizationId,
+      datasetId
+    ) { _ =>
+      getOrCreateDoi(ports, organizationId, datasetId)
+        .flatMap { doi =>
+          ports.log.info(s"DOI: $doi")
+
+          val query = for {
+            publicDataset <- PublicDatasetsMapper
+              .createOrUpdate(
+                name = body.name,
+                sourceOrganizationId = organizationId,
+                sourceOrganizationName = body.organizationName,
+                sourceDatasetId = datasetId,
+                ownerId = body.ownerId,
+                ownerFirstName = body.ownerFirstName,
+                ownerLastName = body.ownerLastName,
+                ownerOrcid = body.ownerOrcid,
+                license = body.license,
+                tags = body.tags.toList
+              )
+            _ = ports.log.info(s"Public dataset: $publicDataset")
+
+            version <- PublicDatasetVersionsMapper
+              .create(
+                id = publicDataset.id,
+                status = PublishStatus.PublishInProgress,
+                size = body.size,
+                description = body.description,
+                modelCount =
+                  body.modelCount.map(o => o.modelName -> o.count).toMap,
+                fileCount = body.fileCount,
+                recordCount = body.recordCount,
+                s3Bucket = targetS3Bucket,
+                embargoReleaseDate = None,
+                doi = doi.doi,
+                schemaVersion = PennsieveSchemaVersion.`4.0`,
+                migrated = true
+              )
+            _ = ports.log.info(s"Public dataset version : $version")
+
+            // TODO: add PublicDatasetRelease
+
+            _ = ports.log.info(s"Internal Contributors : ${body.contributors}")
+            contributors <- DBIO.sequence(body.contributors.map { c =>
+              PublicContributorsMapper
+                .create(
+                  firstName = c.firstName,
+                  middleInitial = c.middleInitial,
+                  lastName = c.lastName,
+                  degree = c.degree,
+                  orcid = c.orcid,
+                  datasetId = publicDataset.id,
+                  version = version.version,
+                  sourceContributorId = c.id,
+                  sourceUserId = c.userId
+                )
+            }.toList)
+            _ = ports.log.info(s"Public dataset contributors: $contributors")
+
+            collections <- DBIO.sequence(
+              body.collections
+                .getOrElse(IndexedSeq())
+                .map { c =>
+                  PublicCollectionsMapper
+                    .create(
+                      name = c.name,
+                      datasetId = publicDataset.id,
+                      version = version.version,
+                      sourceCollectionId = c.id
+                    )
+                }
+                .toList
+            )
+            _ = ports.log.info(s"Public dataset collections: $collections")
+
+            externalPublications <- DBIO.sequence(
+              body.externalPublications
+                .getOrElse(IndexedSeq.empty)
+                .map { p =>
+                  PublicExternalPublicationsMapper.create(
+                    doi = p.doi,
+                    relationshipType =
+                      p.relationshipType.getOrElse(RelationshipType.References),
+                    datasetId = publicDataset.id,
+                    version = version.version
+                  )
+                }
+                .toList
+            )
+            _ = ports.log.info(
+              s"Public external publications: $externalPublications"
+            )
+
+            status <- PublicDatasetVersionsMapper.getDatasetStatus(
+              publicDataset
+            )
+
+          } yield respond.Created(status)
+
+          ports.db
+            .run(
+              query.transactionally
+                .withTransactionIsolation(TransactionIsolation.Serializable)
+            )
+        }
+
+    }.recover {
+      case UnauthorizedException => respond.Unauthorized
+      case DecodingFailure(msg, path) =>
+        respond.InternalServerError(s"Failed to decode DOI: $msg [$path]")
+      case DoiCreationException(e) =>
+        respond.BadRequest(s"Failed to create a DOI for the dataset: $e")
+      case DoiServiceException(e) =>
+        respond.InternalServerError(
+          s"Failed to communicate with DOI service: $e"
+        )
+      case DuplicateDoiException =>
+        respond.InternalServerError(
+          "A dataset version has already been published with this DOI"
+        )
+      case MissingParameterException(parameter) =>
+        respond.BadRequest(s"Missing parameter '$parameter'")
+      case ForbiddenException(e) => respond.Forbidden(e)
+      case PublishJobException(e) => respond.InternalServerError(e.toString)
+      case NonFatal(e) => respond.InternalServerError(e.toString)
+    }
+  }
+
+}

--- a/server/src/main/scala/com/pennsieve/discover/logging/DiscoverLogContext.scala
+++ b/server/src/main/scala/com/pennsieve/discover/logging/DiscoverLogContext.scala
@@ -9,7 +9,10 @@ final case class DiscoverLogContext(
   datasetId: Option[Int] = None,
   userId: Option[Int] = None,
   publicDatasetId: Option[Int] = None,
-  publicDatasetVersion: Option[Int] = None
+  publicDatasetVersion: Option[Int] = None,
+  releaseOrigin: Option[String] = None,
+  releaseRepoUrl: Option[String] = None,
+  releaseLabel: Option[String] = None
 ) extends LogContext {
   override val values: Map[String, String] = inferValues(this)
 }

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetRelease.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetRelease.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+import java.time.{ OffsetDateTime, ZoneOffset }
+
+case class PublicDatasetRelease(
+  id: Int = 0,
+  datasetId: Int,
+  datasetVersion: Int,
+  origin: String,
+  label: String,
+  marker: String,
+  repoUrl: String,
+  labelUrl: Option[String],
+  markerUrl: Option[String],
+  releaseStatus: Option[String],
+  assetFilePrefix: Option[String],
+  assetFileId: Option[Int],
+  createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
+  updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
+)
+
+object PublicDatasetRelease {
+  val tupled = (this.apply _).tupled
+}

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetRelease.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetRelease.scala
@@ -12,11 +12,11 @@ case class PublicDatasetRelease(
   label: String,
   marker: String,
   repoUrl: String,
-  labelUrl: Option[String],
-  markerUrl: Option[String],
-  releaseStatus: Option[String],
-  assetFilePrefix: Option[String],
-  assetFileId: Option[Int],
+  labelUrl: Option[String] = None,
+  markerUrl: Option[String] = None,
+  releaseStatus: Option[String] = None,
+  assetFilePrefix: Option[String] = None,
+  assetFileId: Option[Int] = None,
   createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
   updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
 )

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetReleaseAsset.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetReleaseAsset.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+import com.github.tminglei.slickpg.LTree
+
+import java.time.{ OffsetDateTime, ZoneOffset }
+
+case class PublicDatasetReleaseAsset(
+  id: Int = 0,
+  datasetId: Int,
+  datasetVersion: Int,
+  releaseId: Int,
+  file: String,
+  name: String,
+  `type`: String,
+  size: Long,
+  path: LTree,
+  createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
+  updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
+)
+
+object PublicDatasetReleaseAsset {
+  val tupled = (this.apply _).tupled
+}

--- a/server/src/main/scala/com/pennsieve/discover/utils/BucketResolver.scala
+++ b/server/src/main/scala/com/pennsieve/discover/utils/BucketResolver.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.utils
+
+import com.pennsieve.discover.Ports
+import com.pennsieve.discover.models.S3Bucket
+import com.pennsieve.discover.server.definitions.BucketConfig
+
+object BucketResolver {
+  def apply(ports: Ports): BucketResolver = new BucketResolver(ports)
+}
+
+class BucketResolver(ports: Ports) {
+
+  val defaultPublishBucket = ports.config.s3.publishBucket
+  val defaultEmbargoBucket = ports.config.s3.embargoBucket
+  val defaultPublish50Bucket = ports.config.s3.publish50Bucket
+  val defaultEmbargo50Bucket = ports.config.s3.embargo50Bucket
+
+  private def getDefaultBucket(
+    workflowId: Option[Long],
+    bucket4: S3Bucket,
+    bucket5: S3Bucket
+  ) =
+    workflowId match {
+      case Some(workflowId) =>
+        workflowId match {
+          case 4 => bucket4
+          case _ => bucket5
+        }
+      case None => bucket5
+    }
+
+  def resolveBucketConfig(
+    bucketConfig: Option[BucketConfig],
+    workflowId: Option[Long]
+  ): (S3Bucket, S3Bucket) = {
+    (
+      bucketConfig
+        .map(c => S3Bucket(c.publish))
+        .getOrElse(
+          getDefaultBucket(
+            workflowId,
+            defaultPublishBucket,
+            defaultPublish50Bucket
+          )
+        ),
+      bucketConfig
+        .map(c => S3Bucket(c.embargo))
+        .getOrElse(
+          getDefaultBucket(
+            workflowId,
+            defaultEmbargoBucket,
+            defaultEmbargo50Bucket
+          )
+        )
+    )
+  }
+}

--- a/server/src/test/scala/com/pennsieve/discover/handlers/ReleaseHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/ReleaseHandlerSpec.scala
@@ -1,0 +1,146 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.handlers
+
+import akka.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.pennsieve.auth.middleware.Jwt
+import com.pennsieve.discover.Authenticator.generateServiceToken
+import com.pennsieve.discover.ServiceSpecHarness
+import com.pennsieve.discover.client.definitions
+import com.pennsieve.discover.client.definitions.{
+  DatasetPublishStatus,
+  InternalContributor
+}
+import com.pennsieve.discover.client.publish.{ PublishClient, PublishResponse }
+import com.pennsieve.discover.client.release.{
+  PublishReleaseResponse,
+  ReleaseClient
+}
+import com.pennsieve.discover.models.PublishingWorkflow
+import com.pennsieve.models.{ Degree, License, RelationshipType }
+import com.pennsieve.models.PublishStatus.PublishInProgress
+import com.pennsieve.test.EitherValue._
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ReleaseHandlerSpec
+    extends AnyWordSpec
+    with Matchers
+    with Inside
+    with ScalatestRouteTest
+    with ServiceSpecHarness {
+
+  def createRoutes(): Route =
+    Route.seal(ReleaseHandler.routes(ports))
+
+  def createClient(routes: Route): ReleaseClient =
+    ReleaseClient.httpClient(Route.toFunction(routes))
+
+  val organizationId = 1
+  val organizationNodeId = "N:organization:abc123"
+  val organizationName = "University of Pennsylvania"
+  val datasetName = "Dataset"
+  val datasetId = 34
+  val datasetNodeId = "N:dataset:abc123"
+  val ownerId = 1
+  val ownerNodeId = "N:user:abc123"
+  val ownerFirstName = "Data"
+  val ownerLastName = "Digger"
+  val ownerOrcid = "0000-0012-3456-7890"
+
+  val origin = "GitHub"
+  val repoUrl = "https://github.com/Pennsieve/test-repo"
+  val label = "v1.0.0"
+  val marker = "4b6083761af527c197ee1549c77b30857dec9542"
+
+  val internalContributor =
+    new InternalContributor(
+      1,
+      "Sally",
+      "Field",
+      middleInitial = Some("M"),
+      degree = Some(Degree.BS)
+    )
+
+  val internalExternalPublication =
+    new definitions.InternalExternalPublication(
+      doi = "10.26275/t6j6-77pu",
+      relationshipType = Some(RelationshipType.Describes)
+    )
+
+  val client = createClient(createRoutes())
+  val token: Jwt.Token =
+    generateServiceToken(
+      ports.jwt,
+      organizationId = organizationId,
+      datasetId = datasetId
+    )
+
+  val authToken = List(Authorization(OAuth2BearerToken(token.value)))
+
+  def releaseRequest(
+    origin: String,
+    label: String,
+    marker: String,
+    repoUrl: String,
+    labelUrl: Option[String] = None,
+    markerUrl: Option[String] = None,
+    releaseStatus: Option[String] = None
+  ): definitions.PublishReleaseRequest = {
+    definitions.PublishReleaseRequest(
+      name = datasetName,
+      description = "A very very long description...",
+      ownerId = 1,
+      modelCount = Vector(definitions.ModelCount("myConcept", 100L)),
+      recordCount = 100L,
+      fileCount = 100L,
+      size = 5555555L,
+      license = License.`Apache 2.0`,
+      contributors = Vector(internalContributor),
+      externalPublications = Some(Vector(internalExternalPublication)),
+      tags = Vector[String]("tag1", "tag2"),
+      ownerNodeId = ownerNodeId,
+      ownerFirstName = ownerFirstName,
+      ownerLastName = ownerLastName,
+      ownerOrcid = ownerOrcid,
+      organizationNodeId = organizationNodeId,
+      organizationName = organizationName,
+      datasetNodeId = datasetNodeId,
+      workflowId = Some(5),
+      origin = origin,
+      label = label,
+      marker = marker,
+      repoUrl = repoUrl,
+      labelUrl = labelUrl,
+      markerUrl = markerUrl,
+      releaseStatus = releaseStatus
+    )
+  }
+
+  "POST /organizations/{organizationId}/datasets/{datasetId}/release" should {
+    "create a dataset, version and release" in {
+      val requestBody = releaseRequest(origin, label, marker, repoUrl)
+      val response = client
+        .publishRelease(organizationId, datasetId, requestBody, authToken)
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishReleaseResponse.Created]
+        .value
+
+      response shouldBe DatasetPublishStatus(
+        datasetName,
+        organizationId,
+        datasetId,
+        None,
+        0,
+        PublishInProgress,
+        None,
+        workflowId = PublishingWorkflow.Version5
+      )
+    }
+  }
+
+}


### PR DESCRIPTION
This PR adds the first set of capability needed in the *Discover Service* to support publishing datasets of type release. 

**Database changes:**
- adding `type` column to PublicDatasets table
- adding tables to store release-specific information:
  - PublicDatasetRelease: holds the release details like origin ("GitHub"), label (the tag), marker (the commit hash), and repo url
  - PublicDatasetReleaseAssets: a listing of the release asset (Zip file content)

**API Changes:**
- added new endpoint that is called at the initiation of the publishing workflow
- the endpoint does the following:
  - gets or creates a DOI for the publication
  - creates the public dataset, public dataset version, and public dataset release database items
  - adds contributors, collections, and external publications

**Refactoring:**
- moved S3 Bucket resolution to its own class/object
- moved `getOrCreateDoi()` to the **utils** package object