### PR TITLE
Feature/workspace specific metadata

### DIFF
--- a/server/src/main/resources/db/migration/V20240802133900__add_workspace_metadata_table.sql
+++ b/server/src/main/resources/db/migration/V20240802133900__add_workspace_metadata_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE workspace_settings (
+    id SERIAL PRIMARY KEY,
+    organization_id INT NOT NULL,
+    publisher_name TEXT NOT NULL,
+    redirect_url TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+)
+
+CREATE TRIGGER workspace_settings_updated_at
+    BEFORE UPDATE ON workspace_settings
+    FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();

--- a/server/src/main/resources/db/migration/V20240802133900__add_workspace_metadata_table.sql
+++ b/server/src/main/resources/db/migration/V20240802133900__add_workspace_metadata_table.sql
@@ -5,7 +5,7 @@ CREATE TABLE workspace_settings (
     redirect_url TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-)
+);
 
 CREATE TRIGGER workspace_settings_updated_at
     BEFORE UPDATE ON workspace_settings

--- a/server/src/main/resources/db/migration/V20240802133900__add_workspace_metadata_table.sql
+++ b/server/src/main/resources/db/migration/V20240802133900__add_workspace_metadata_table.sql
@@ -4,7 +4,8 @@ CREATE TABLE workspace_settings (
     publisher_name TEXT NOT NULL,
     redirect_url TEXT NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(organization_id)
 );
 
 CREATE TRIGGER workspace_settings_updated_at

--- a/server/src/main/scala/com/pennsieve/discover/db/WorkspaceSettingsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/WorkspaceSettingsTable.scala
@@ -25,6 +25,18 @@ final class WorkspaceSettingsTable(tag: Tag)
 
 object WorkspaceSettingsMapper
     extends TableQuery(new WorkspaceSettingsTable(_)) {
+
+  def addSettings(
+    settings: WorkspaceSettings
+  )(implicit
+    executionContext: ExecutionContext
+  ): DBIOAction[
+    WorkspaceSettings,
+    NoStream,
+    Effect.Read with Effect.Write with Effect
+  ] =
+    (this returning this) += settings
+
   def getSettings(
     organizationId: Int
   )(implicit

--- a/server/src/main/scala/com/pennsieve/discover/db/WorkspaceSettingsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/WorkspaceSettingsTable.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.db
+
+import com.pennsieve.discover.db.profile.api._
+import com.pennsieve.discover.models.WorkspaceSettings
+
+import java.time.OffsetDateTime
+import scala.concurrent.ExecutionContext
+
+final class WorkspaceSettingsTable(tag: Tag)
+    extends Table[WorkspaceSettings](tag, "workspace_settings") {
+
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def organizationId = column[Int]("organization_id")
+  def publisherName = column[String]("publisher_name")
+  def redirectUrl = column[String]("redirect_url")
+  def createdAt = column[OffsetDateTime]("created_at")
+  def updatedAt = column[OffsetDateTime]("updated_at")
+
+  def * =
+    (id, organizationId, publisherName, redirectUrl, createdAt, updatedAt)
+      .mapTo[WorkspaceSettings]
+}
+
+object WorkspaceSettingsMapper
+    extends TableQuery(new WorkspaceSettingsTable(_)) {
+  def getSettings(
+    organizationId: Int
+  )(implicit
+    executionContext: ExecutionContext
+  ): DBIOAction[Option[WorkspaceSettings], NoStream, Effect.Read with Effect] =
+    this
+      .filter(_.organizationId === organizationId)
+      .result
+      .headOption
+}

--- a/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
@@ -2,45 +2,20 @@
 
 package com.pennsieve.discover.models
 
+class DoiRedirect(settings: WorkspaceSettings) {
+  def getPublisher(): String = settings.publisherName
+  def getUrl(datasetId: Int, versionId: Int): String = {
+    val replacements = Map(
+      "{{datasetId}}" -> datasetId.toString,
+      "{{versionId}}" -> versionId.toString
+    )
+    replacements.foldLeft(settings.redirectUrl)(
+      (a, b) => a.replaceAllLiterally(b._1, b._2)
+    )
+  }
+}
+
 object DoiRedirect {
-  def getUrl(
-    publicDiscoverUrl: String,
-    publicDataset: PublicDataset,
-    publicVersion: PublicDatasetVersion
-  ): String = {
-    if ((publicDataset.sourceOrganizationName == "SPARC" || publicDataset.sourceOrganizationName == "SPARC Consortium") &&
-      publicDiscoverUrl == "https://discover.pennsieve.io") {
-      getSPARCUrl(publicDataset.id, publicVersion.version)
-    } else if (publicDataset.sourceOrganizationName == "RE-JOIN" && publicDiscoverUrl == "https://discover.pennsieve.io") {
-      getSPARCUrl(publicDataset.id, publicVersion.version)
-    } else if (publicDataset.sourceOrganizationName == "HEAL PRECISION" && publicDiscoverUrl == "https://discover.pennsieve.io") {
-      getSPARCUrl(publicDataset.id, publicVersion.version)
-    } else {
-      getDiscoverUrl(publicDiscoverUrl, publicDataset.id, publicVersion.version)
-    }
-  }
-
-  def getPublisher(publicDataset: PublicDataset): Option[String] = {
-    if ((publicDataset.sourceOrganizationName == "SPARC" || publicDataset.sourceOrganizationName == "SPARC Consortium")) {
-      Some("SPARC Consortium")
-    } else if (publicDataset.sourceOrganizationName == "RE-JOIN") {
-      Some("RE-JOIN Consortium")
-    } else if (publicDataset.sourceOrganizationName == "HEAL PRECISION") {
-      Some("HEAL PRECISION Consortium")
-    } else {
-      Some("Pennsieve Discover")
-    }
-  }
-
-  def getSPARCUrl(datasetId: Int, version: Int): String = {
-    s"https://sparc.science/datasets/${datasetId}/version/${version}"
-  }
-
-  def getDiscoverUrl(
-    publicDiscoverUrl: String,
-    datasetId: Int,
-    version: Int
-  ): String = {
-    s"${publicDiscoverUrl}/datasets/${datasetId}/version/${version}"
-  }
+  def apply(settings: WorkspaceSettings): DoiRedirect =
+    new DoiRedirect(settings)
 }

--- a/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
@@ -9,9 +9,7 @@ class DoiRedirect(settings: WorkspaceSettings) {
       "{{datasetId}}" -> datasetId.toString,
       "{{versionId}}" -> versionId.toString
     )
-    replacements.foldLeft(settings.redirectUrl)(
-      (a, b) => a.replaceAllLiterally(b._1, b._2)
-    )
+    replacements.foldLeft(settings.redirectUrl)((a, b) => a.replace(b._1, b._2))
   }
 }
 

--- a/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
@@ -14,10 +14,11 @@ case class WorkspaceSettings(
 )
 
 object WorkspaceSettings {
+  def defaultPublisher = "Pennsieve Discover"
   def default(publicUrl: String): WorkspaceSettings =
     WorkspaceSettings(
       organizationId = 0,
-      publisherName = "Pennsieve",
+      publisherName = defaultPublisher,
       redirectUrl = s"${publicUrl}/datasets/{{datasetId}}/version/{{versionId}}"
     )
 

--- a/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+import java.time.{ OffsetDateTime, ZoneOffset }
+
+case class WorkspaceSettings(
+  id: Int = 0,
+  organizationId: Int,
+  publisherName: String,
+  redirectUrl: String,
+  createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
+  updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
+)
+
+object WorkspaceSettings {
+  def default(publicUrl: String): WorkspaceSettings =
+    WorkspaceSettings(
+      organizationId = 0,
+      publisherName = "Pennsieve",
+      redirectUrl = s"${publicUrl}/datasets/{{datasetId}}/version/{{versionId}}"
+    )
+
+  val tupled = (this.apply _).tupled
+}

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockDoiClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockDoiClient.scala
@@ -41,7 +41,7 @@ class MockDoiClient(
       organizationId = organizationId,
       datasetId = datasetId,
       doi = doi,
-      publisher = "Pennsieve Discover",
+      publisher = WorkspaceSettings.defaultPublisher,
       url = None,
       createdAt = Some("4/18/2019"),
       publicationYear = None,
@@ -98,7 +98,8 @@ class MockDoiClient(
           title = Some(name),
           creators = Some(contributors.map(c => Some(c.fullName))),
           publicationYear = Some(publicationYear),
-          url = Some(url)
+          url = Some(url),
+          publisher = publisher.getOrElse(dto.publisher)
         )
         dois += doi -> published
         Future.successful(published)


### PR DESCRIPTION
This PR adds the ability to set and use organization-specific settings for two DOI values:
- **Publisher**: the name that appears as the publishing authority (default is Pennsieve Discover)
- **Redirect URL**: the URL that the DOI link will resolve to (default is https://discover.pennsieve.{env})

This is achieved by storing a workspace's settings in the database table: `workspace_settings`, and refactoring the `DoiRedirect` object into a class that utilizes the settings. 

ClickUp ticket: [Discover: Workspace-specific Metadata](https://app.clickup.com/t/86894wm4h)

Note: there is no API endpoint or purpose-built tool to set or modify the `workspace_settings` table. Values must be set by inserting into or updating the table using a SQL/database tool.