### PR TITLE
Discover Service - fix Embargo related bugs

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -516,7 +516,7 @@ class SQSNotificationHandler(
       // if this is a Publishing 5.0 dataset, then update the S3 Version of the Files
       _ <- updatedVersion.migrated match {
         case true =>
-          releaseUpdateFileVersions(version)
+          releaseUpdateFileVersions(updatedVersion)
         case false =>
           Future.successful(())
       }

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -1651,7 +1651,7 @@ class PublishHandlerSpec
           organizationId,
           datasetId,
           Some(true),
-          Some(LocalDate.now),
+          Some(LocalDate.now().plusDays(1)),
           requestBody,
           authToken
         )

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -2092,4 +2092,172 @@ class PublishHandlerSpec
     }
   }
 
+  "Embargo request" should {
+    "not Embargo with a release date before today" in {
+      val expectedEmbargoReleaseDate = LocalDate.now().minusDays(1)
+
+      val response = client
+        .publish(
+          organizationId,
+          datasetId,
+          Some(true),
+          Some(expectedEmbargoReleaseDate),
+          requestBody,
+          authToken
+        )
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishResponse.Created]
+        .value
+
+      response shouldBe DatasetPublishStatus(
+        datasetName,
+        organizationId,
+        datasetId,
+        None,
+        0,
+        PublishStatus.PublishInProgress,
+        None,
+        workflowId = PublishingWorkflow.Version4
+      )
+
+      val publicDataset = ports.db
+        .run(
+          PublicDatasetsMapper
+            .getDatasetFromSourceIds(organizationId, datasetId)
+        )
+        .awaitFinite()
+
+      publicDataset.name shouldBe requestBody.name
+      publicDataset.sourceOrganizationId shouldBe organizationId
+      publicDataset.sourceDatasetId shouldBe datasetId
+      publicDataset.ownerId shouldBe requestBody.ownerId
+      publicDataset.ownerFirstName shouldBe requestBody.ownerFirstName
+      publicDataset.ownerLastName shouldBe requestBody.ownerLastName
+      publicDataset.ownerOrcid shouldBe requestBody.ownerOrcid
+
+      val publicVersion = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getLatestVersion(publicDataset.id)
+        )
+        .awaitFinite()
+        .get
+
+      val doiDto = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .getMockDoi(organizationId, datasetId)
+        .get
+
+      publicVersion.version shouldBe 1
+      publicVersion.modelCount shouldBe Map[String, Long]("myConcept" -> 100L)
+      publicVersion.recordCount shouldBe requestBody.recordCount
+      publicVersion.fileCount shouldBe requestBody.fileCount
+      publicVersion.size shouldBe requestBody.size
+      publicVersion.description shouldBe requestBody.description
+      publicVersion.status shouldBe PublishStatus.PublishInProgress
+      publicVersion.s3Bucket shouldBe config.s3.publishBucket
+      publicVersion.s3Key shouldBe S3Key.Version(
+        s"${publicDataset.id}/${publicVersion.version}/"
+      )
+      publicVersion.doi shouldBe doiDto.doi
+      publicVersion.embargoReleaseDate shouldBe None
+
+      val publishedJobs = ports.stepFunctionsClient
+        .asInstanceOf[MockStepFunctionsClient]
+        .startedJobs
+
+      publishedJobs.length shouldBe 1
+      publishedJobs.head.s3Bucket shouldBe config.s3.publishBucket
+    }
+
+    "not Embargo with release date of today" in {
+      val expectedEmbargoReleaseDate = LocalDate.now()
+
+      val response = client
+        .publish(
+          organizationId,
+          datasetId,
+          Some(true),
+          Some(expectedEmbargoReleaseDate),
+          requestBody,
+          authToken
+        )
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishResponse.Created]
+        .value
+
+      response shouldBe DatasetPublishStatus(
+        datasetName,
+        organizationId,
+        datasetId,
+        None,
+        0,
+        PublishStatus.PublishInProgress,
+        None,
+        workflowId = PublishingWorkflow.Version4
+      )
+
+      val publicDataset = ports.db
+        .run(
+          PublicDatasetsMapper
+            .getDatasetFromSourceIds(organizationId, datasetId)
+        )
+        .awaitFinite()
+
+      publicDataset.name shouldBe requestBody.name
+      publicDataset.sourceOrganizationId shouldBe organizationId
+      publicDataset.sourceDatasetId shouldBe datasetId
+      publicDataset.ownerId shouldBe requestBody.ownerId
+      publicDataset.ownerFirstName shouldBe requestBody.ownerFirstName
+      publicDataset.ownerLastName shouldBe requestBody.ownerLastName
+      publicDataset.ownerOrcid shouldBe requestBody.ownerOrcid
+
+      val publicVersion = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getLatestVersion(publicDataset.id)
+        )
+        .awaitFinite()
+        .get
+
+      val doiDto = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .getMockDoi(organizationId, datasetId)
+        .get
+
+      publicVersion.version shouldBe 1
+      publicVersion.modelCount shouldBe Map[String, Long]("myConcept" -> 100L)
+      publicVersion.recordCount shouldBe requestBody.recordCount
+      publicVersion.fileCount shouldBe requestBody.fileCount
+      publicVersion.size shouldBe requestBody.size
+      publicVersion.description shouldBe requestBody.description
+      publicVersion.status shouldBe PublishStatus.PublishInProgress
+      publicVersion.s3Bucket shouldBe config.s3.publishBucket
+      publicVersion.s3Key shouldBe S3Key.Version(
+        s"${publicDataset.id}/${publicVersion.version}/"
+      )
+      publicVersion.doi shouldBe doiDto.doi
+      publicVersion.embargoReleaseDate shouldBe None
+
+      val publishedJobs = ports.stepFunctionsClient
+        .asInstanceOf[MockStepFunctionsClient]
+        .startedJobs
+
+      publishedJobs.length shouldBe 1
+      publishedJobs.head.s3Bucket shouldBe config.s3.publishBucket
+    }
+
+    "check Release Dates are after today" in {
+      val yesterday = LocalDate.now().minusDays(1)
+      val today = LocalDate.now()
+      val tomorrow = LocalDate.now().plusDays(1)
+
+      yesterday.isAfter(today) shouldBe false
+      today.isAfter(today) shouldBe false
+      tomorrow.isAfter(today) shouldBe true
+    }
+  }
+
 }


### PR DESCRIPTION
This fixes two issues in the Discover Service:
1. [Embargo Release fails for custom buckets](https://app.clickup.com/t/86889pz4w)
   - in `handleReleaseSuccess()` the **PublicDatasetVersion** is updated changing the S3 Bucket value to the publish bucket. But the previous **PublicDatasetVersion**, on which the S3 Bucket is the embargo bucket, was passed to `releaseUpdateFileVersions()`. This was causing the Discover Service to look in the wrong bucket for the Discover Release result file. 
2. [Embargo Release in the past should not Embargo](https://app.clickup.com/t/868aewrqw)
   - if an embargo request is received and the release rate is not *after* today, then publish the dataset without an embargo period. Several SPARC datasets were submitted for publishing review with embargo dates, but the embargo time period lapsed while the dataset was under review. This caused an inefficiency where the dataset would be published under embargo and then released at the next scan period (up to 1 hour later).