### PR TITLE
handle unavailable S3 objects

### DIFF
--- a/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
@@ -273,24 +273,24 @@ class MockS3StreamClient extends S3StreamClient {
     versionId: Option[S3Key.Version]
   )(implicit
     ec: ExecutionContext
-  ): Future[ByteString] = Future.successful(ByteString.empty)
+  ): Future[Option[ByteString]] = Future.successful(Some(ByteString.empty))
 
   override def loadDatasetMetadata(
     version: PublicDatasetVersion
   )(implicit
     ec: ExecutionContext
-  ): Future[DatasetMetadata] =
+  ): Future[Option[DatasetMetadata]] =
     for {
-      output <- decode[DatasetMetadata](sampleMetadata)
+      output: DatasetMetadata <- decode[DatasetMetadata](sampleMetadata)
         .fold(Future.failed, Future.successful)
-    } yield output
+    } yield Some(output)
 
   override def loadReleaseAssetListing(
     version: PublicDatasetVersion
   )(implicit
     ec: ExecutionContext
-  ): Future[ReleaseAssetListing] =
-    Future.successful(ReleaseAssetListing(files = List.empty))
+  ): Future[Option[ReleaseAssetListing]] =
+    Future.successful(Some(ReleaseAssetListing(files = List.empty)))
 
 }
 

--- a/server/src/test/scala/com/pennsieve/discover/models/JsonEncodingSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/models/JsonEncodingSpec.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+import org.scalatest.Suite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import io.circe.parser.decode
+
+class JsonEncodingSpec extends AnyWordSpec with Suite with Matchers {
+  "JSON Encoding" should {
+    "decode a ReleaseAssetListing" in {
+      val jsonString =
+        s"""
+           |{"files":[{"file":"manifest.json","name":"manifest.json","type":"file","size":1234},{"file":"metadata.json","name":"metadata.json","type":"file","size":2345}]}
+           |""".stripMargin
+
+      val expected = ReleaseAssetListing(
+        files = Seq(
+          ReleaseAssetFile(
+            file = "manifest.json",
+            name = "manifest.json",
+            `type` = ReleaseAssetFileType.File,
+            size = 1234
+          ),
+          ReleaseAssetFile(
+            file = "metadata.json",
+            name = "metadata.json",
+            `type` = ReleaseAssetFileType.File,
+            size = 2345
+          )
+        )
+      )
+      val decoded = decode[ReleaseAssetListing](jsonString)
+        .fold(l => (), r => r)
+
+      decoded shouldEqual expected
+    }
+  }
+}


### PR DESCRIPTION
Modified the `S3StreamClient` to return `Option[ByteString]` when performing a `GetObject()`. When S3 returns the `NoSuchKeyException` we swallow that and return a `None`.

Updated the `ReleaseHandler.finalizeRelease()` to cope with "missing" data when loading the Dataset Manifest (`manifest.json`) and the Release Asset Listing. The former case is an error, and the operation fails. The latter case is not necessarily an error. If the Zip data from GitHub is deemed invalid, then a Release Asset Listing will not be generated. In this case, we log a warning and proceed -- no failure is generated.