### PR TITLE
Fix Browse Assets function

### DIFF
--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -538,6 +538,65 @@ paths:
               schema:
                 $ref: "#/components/schemas/TombstoneDTO"
 
+  "/datasets/{datasetId}/versions/{versionId}/assets":
+    get:
+      tags:
+        - Datasets
+      security: [ ]
+      summary: get all release assets for a dataset
+      operationId: browseAllAssets
+      x-scala-package: dataset
+      description: >
+        Return all files and folders in the release asset.
+        This endpoint is not paginated.
+      parameters:
+        - name: datasetId
+          in: path
+          description: dataset id
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: versionId
+          in: path
+          description: version number
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AssetTreePage"
+        "401":
+          description: dataset is under embargo
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: dataset is under embargo
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: resource not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "410":
+          description: dataset unpublished
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TombstoneDTO"
+
+
   "/datasets/{datasetId}/versions/{versionId}/assets/browse":
     get:
       tags:

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseAssetsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseAssetsTable.scala
@@ -204,13 +204,10 @@ object PublicDatasetReleaseAssetMapper
       : GetResult[Either[TotalCount, AssetTreeNode]] =
       buildAssetNodeGetter()
 
-    val parent = convertPathToTree(path match {
-      case Some(d) => version.s3Key / d
-      case None => version.s3Key / ""
-    })
-
-    // selects leaves of the tree one level under parent
-    val leafChildSelector = parent + ".*{1}"
+    val leafChildSelector = path match {
+      case Some(path) => convertPathToTree(S3Key.File(path)) + ".*{1}"
+      case None => "*{1}"
+    }
 
     val datasetId = version.datasetId
     val datasetVersion = version.version

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -287,8 +287,6 @@ object TestUtilities extends AwaitableImplicits {
       .await
   }
 
-  //def setupForReleaseAssetTesting(db: Database)
-
   def createRevision(
     db: Database
   )(

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -2,6 +2,7 @@
 
 package com.pennsieve.discover
 
+import akka.Done
 import com.pennsieve.discover.db._
 import com.pennsieve.discover.db.profile.api._
 import com.pennsieve.discover.models._
@@ -270,6 +271,23 @@ object TestUtilities extends AwaitableImplicits {
       )
       .await
   }
+
+  def addReleaseAssetFiles(
+    db: Database
+  )(
+    version: PublicDatasetVersion,
+    release: PublicDatasetRelease,
+    listing: ReleaseAssetListing
+  )(implicit
+    executionContext: ExecutionContext
+  ): Done = {
+    db.run(
+        PublicDatasetReleaseAssetMapper.createMany(version, release, listing)
+      )
+      .await
+  }
+
+  //def setupForReleaseAssetTesting(db: Database)
 
   def createRevision(
     db: Database

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -47,7 +47,10 @@ import com.pennsieve.discover.db.{
   SponsorshipsMapper
 }
 import com.pennsieve.discover.models._
-import com.pennsieve.discover.server.definitions.SponsorshipDto
+import com.pennsieve.discover.server.definitions.{
+  AssetTreePage,
+  SponsorshipDto
+}
 import com.pennsieve.models.PublishStatus.{
   EmbargoSucceeded,
   NotPublished,
@@ -2551,8 +2554,180 @@ class DatasetHandlerSpec
     }
   }
 
+  def setupForReleaseAssetTesting(
+  ): (PublicDataset, PublicDatasetVersion, ReleaseAssetListing) = {
+    // create dataset
+    val dataset = TestUtilities.createDataset(ports.db)(
+      name = "filtered dataset 1",
+      datasetType = DatasetType.Release,
+      sourceOrganizationId = 1,
+      sourceDatasetId = 333
+    )
+
+    // create version
+    val version: PublicDatasetVersion =
+      TestUtilities.createNewDatasetVersion(ports.db)(
+        id = dataset.id,
+        status = PublishStatus.PublishSucceeded
+      )
+    // create release
+    val release: PublicDatasetRelease =
+      TestUtilities.createDatasetRelease(ports.db)(
+        dataset.id,
+        version.version,
+        "GitHub",
+        "v1.2.3",
+        "https://github.com/pennsieve/test-browse-repo",
+        "1a2b3c4d5e6f7g8h9i"
+      )
+
+    // create assets
+    val listing = ReleaseAssetListing(
+      files = List(
+        ReleaseAssetFile(
+          file = "LICENSE",
+          name = "LICENSE",
+          `type` = ReleaseAssetFileType.File,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "README.md",
+          name = "README.md",
+          `type` = ReleaseAssetFileType.File,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "CHANGELOG.md",
+          name = "CHANGELOG.md",
+          `type` = ReleaseAssetFileType.File,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "code/",
+          name = "code",
+          `type` = ReleaseAssetFileType.Folder,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "code/main.py",
+          name = "main.py",
+          `type` = ReleaseAssetFileType.File,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "code/utils.py",
+          name = "utils.py",
+          `type` = ReleaseAssetFileType.File,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "code/reporting.py",
+          name = "reporting.py",
+          `type` = ReleaseAssetFileType.File,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "code/testing/",
+          name = "testing",
+          `type` = ReleaseAssetFileType.Folder,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "code/testing/run-tests.py",
+          name = "run-tests.py",
+          `type` = ReleaseAssetFileType.File,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "data/",
+          name = "data",
+          `type` = ReleaseAssetFileType.Folder,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "data/subjects.csv",
+          name = "subjects.csv",
+          `type` = ReleaseAssetFileType.File,
+          size = 0
+        ),
+        ReleaseAssetFile(
+          file = "data/metadata.dat",
+          name = "metadata.dat",
+          `type` = ReleaseAssetFileType.File,
+          size = 0
+        )
+      )
+    )
+    val _ =
+      TestUtilities.addReleaseAssetFiles(ports.db)(version, release, listing)
+
+    (dataset, version, listing)
+  }
+
   "release asset browse" should {
-    "return all assets" in {}
-    "return only selected assets" in {}
+    "return all assets" in {
+      val (dataset, version, listing) = setupForReleaseAssetTesting()
+
+      val response = datasetClient
+        .browseAllAssets(dataset.id, version.version)
+        .awaitFinite()
+        .value
+        .asInstanceOf[BrowseAllAssetsResponse.OK]
+        .value
+
+      response.assets.length shouldEqual listing.files.length
+    }
+
+    "return top-level assets" in {
+      val (dataset, version, listing) = setupForReleaseAssetTesting()
+
+      val response = datasetClient
+        .browseAssets(dataset.id, version.version, path = None)
+        .awaitFinite()
+        .value
+        .asInstanceOf[BrowseAssetsResponse.OK]
+        .value
+
+      response.assets.length shouldEqual 5
+    }
+
+    "return only selected assets" in {
+      val (dataset, version, listing) = setupForReleaseAssetTesting()
+
+      val response = datasetClient
+        .browseAssets(dataset.id, version.version, path = Some("code"))
+        .awaitFinite()
+        .value
+        .asInstanceOf[BrowseAssetsResponse.OK]
+        .value
+
+      response.assets.length shouldEqual 4
+    }
+
+    "return assets from nested folder" in {
+      val (dataset, version, listing) = setupForReleaseAssetTesting()
+
+      val response = datasetClient
+        .browseAssets(dataset.id, version.version, path = Some("code/testing"))
+        .awaitFinite()
+        .value
+        .asInstanceOf[BrowseAssetsResponse.OK]
+        .value
+
+      response.assets.length shouldEqual 1
+    }
+
+    "return nothing when path does not exist" in {
+      val (dataset, version, listing) = setupForReleaseAssetTesting()
+
+      val response = datasetClient
+        .browseAssets(dataset.id, version.version, path = Some("nothing"))
+        .awaitFinite()
+        .value
+        .asInstanceOf[BrowseAssetsResponse.OK]
+        .value
+
+      response.assets.length shouldEqual 0
+    }
   }
 }

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -2550,4 +2550,9 @@ class DatasetHandlerSpec
       )
     }
   }
+
+  "release asset browse" should {
+    "return all assets" in {}
+    "return only selected assets" in {}
+  }
 }


### PR DESCRIPTION
Fixed the *ltree* query predicate in `PublicDatasetReleaseAssetMapper.childrenOf()` - (1) do not include the Dataset Version S3 Prefix, (2) correctly form a top-level query when path is not provided.

Added an API endpoint to get all Release Assets:
- **GET** `/datasets/{datasetId}/versions/{versionId}/assets`