### PR TITLE
Fix Browse Assets when path is the empty string

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
@@ -850,6 +850,16 @@ class DatasetHandler(
     limit: Option[Int],
     offset: Option[Int]
   ): Future[GuardrailResource.BrowseAssetsResponse] = {
+    def valid(path: Option[String]): Option[String] =
+      path match {
+        case None => None
+        case Some(path) =>
+          path.length match {
+            case 0 => None
+            case _ => Some(path)
+          }
+      }
+
     val query = for {
       dataset <- PublicDatasetsMapper.getDataset(datasetId)
       version <- PublicDatasetVersionsMapper.getVisibleVersion(
@@ -861,7 +871,7 @@ class DatasetHandler(
       (totalCount, assets) <- PublicDatasetReleaseAssetMapper
         .childrenOf(
           version,
-          path,
+          valid(path),
           limit = limit.getOrElse(defaultFileLimit),
           offset = offset.getOrElse(defaultFileOffset)
         )

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -2729,5 +2729,18 @@ class DatasetHandlerSpec
 
       response.assets.length shouldEqual 0
     }
+
+    "not throw Internal Server Error when path is the empty string" in {
+      val (dataset, version, listing) = setupForReleaseAssetTesting()
+
+      val response = datasetClient
+        .browseAssets(dataset.id, version.version, path = Some(""))
+        .awaitFinite()
+        .value
+        .asInstanceOf[BrowseAssetsResponse.OK]
+        .value
+
+      response.assets.length shouldEqual 5
+    }
   }
 }


### PR DESCRIPTION
When the `path` query parameter is provided and the value is the empty string (""), treat path as `None`.