### PR TITLE
Discover Service Updates

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -169,6 +169,10 @@ external-publish-buckets = [
         bucket = ${SPARC_EMBARGO_50_BUCKET}
         role-arn = ${SPARC_BUCKET_ROLE_ARN}
     },
+    {
+        bucket = ${AWSOD_SPARC_PUBLISH_50_BUCKET}
+        role-arn = ${AWSOD_SPARC_BUCKET_ROLE_ARN}
+    },
     # RE-JOIN Buckets
     {
         bucket = ${REJOIN_PUBLISH_50_BUCKET}

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -192,3 +192,8 @@ external-publish-buckets = [
         role-arn = ${REJOIN_BUCKET_ROLE_ARN}
     },
 ]
+
+runtime-settings = {
+    delete-release-intermediate-file = "false"
+    delete-release-intermediate-file = ${?DELETE_RELEASE_INTERMEDIATE_FILES}
+}

--- a/server/src/main/resources/db/migration/V20250228113900__alter_workspace_metadata_table.sql
+++ b/server/src/main/resources/db/migration/V20250228113900__alter_workspace_metadata_table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspace_settings
+  ADD COLUMN redirect_release_url TEXT;

--- a/server/src/main/scala/com/pennsieve/discover/Config.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Config.scala
@@ -32,7 +32,8 @@ case class Config(
   authorizationService: AuthorizationConfiguration,
   download: DownloadConfiguration,
   externalPublishBuckets: Map[S3Bucket, Arn] = Map.empty,
-  athena: AthenaConfig
+  athena: AthenaConfig,
+  runtimeSettings: RuntimeSettings
 )
 
 object Config {
@@ -126,3 +127,5 @@ case class AthenaConfig(
   sparcBucketAccessTable: String,
   rejoinBucketAccessTable: String
 )
+
+case class RuntimeSettings(deleteReleaseIntermediateFile: Boolean)

--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -1019,7 +1019,7 @@ class AlpakkaS3StreamClient(
     system: ActorSystem,
     ec: ExecutionContext
   ): Future[Unit] =
-    Future(())
+    Future(s3DeleteObject(version.s3Bucket, releaseResultKey(version), None))
 
   private def s3Headers(isRequesterPays: Boolean): S3Headers =
     if (!isRequesterPays) S3Headers.empty

--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -162,7 +162,7 @@ trait S3StreamClient {
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
-  ): Future[List[ReleaseAction]]
+  ): Future[List[ReleaseActionV50]]
 
   def deletePublishJobOutput(
     version: PublicDatasetVersion
@@ -988,7 +988,7 @@ class AlpakkaS3StreamClient(
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
-  ): Future[List[ReleaseAction]] =
+  ): Future[List[ReleaseActionV50]] =
     for {
       (source, _) <- s3FileSource(
         version.s3Bucket,
@@ -1000,7 +1000,7 @@ class AlpakkaS3StreamClient(
         .runWith(Sink.fold(ByteString.empty)(_ ++ _))
         .map(_.utf8String)
 
-      output <- decode[List[ReleaseAction]](content)
+      output <- decode[List[ReleaseActionV50]](content)
         .fold(Future.failed, Future.successful)
 
     } yield output

--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -170,7 +170,7 @@ trait S3StreamClient {
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
-  ): Future[Unit]
+  ): Future[Boolean]
 
   def deletePublishJobOutput(
     version: PublicDatasetVersion
@@ -1018,8 +1018,11 @@ class AlpakkaS3StreamClient(
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
-  ): Future[Unit] =
-    Future(s3DeleteObject(version.s3Bucket, releaseResultKey(version), None))
+  ): Future[Boolean] =
+    (for {
+      _ <- s3DeleteObject(version.s3Bucket, releaseResultKey(version), None)
+    } yield true)
+      .recover { case _: Throwable => false }
 
   private def s3Headers(isRequesterPays: Boolean): S3Headers =
     if (!isRequesterPays) S3Headers.empty

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicFileVersionsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicFileVersionsTable.scala
@@ -472,7 +472,7 @@ object PublicFileVersionsMapper
       )
     } yield updated
 
-  def updateManyReleases(
+  def updateReleasedFiles(
     version: PublicDatasetVersion,
     actions: List[ReleaseActionV50]
   )(implicit

--- a/server/src/main/scala/com/pennsieve/discover/db/WorkspaceSettingsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/WorkspaceSettingsTable.scala
@@ -15,12 +15,20 @@ final class WorkspaceSettingsTable(tag: Tag)
   def organizationId = column[Int]("organization_id")
   def publisherName = column[String]("publisher_name")
   def redirectUrl = column[String]("redirect_url")
+  def redirectReleaseUrl = column[Option[String]]("redirect_release_url")
   def createdAt = column[OffsetDateTime]("created_at")
   def updatedAt = column[OffsetDateTime]("updated_at")
 
   def * =
-    (id, organizationId, publisherName, redirectUrl, createdAt, updatedAt)
-      .mapTo[WorkspaceSettings]
+    (
+      id,
+      organizationId,
+      publisherName,
+      redirectUrl,
+      redirectReleaseUrl,
+      createdAt,
+      updatedAt
+    ).mapTo[WorkspaceSettings]
 }
 
 object WorkspaceSettingsMapper

--- a/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
@@ -226,6 +226,12 @@ class PublishHandler(
               case _ => requestedWorkflow
             }
 
+            // ensure we use the same S3 Bucket as previous published versions
+            destinationS3Bucket = latest match {
+              case Some(version) => version.s3Bucket
+              case None => targetS3Bucket
+            }
+
             version <- PublicDatasetVersionsMapper
               .create(
                 id = publicDataset.id,
@@ -238,7 +244,7 @@ class PublishHandler(
                   body.modelCount.map(o => o.modelName -> o.count).toMap,
                 fileCount = body.fileCount,
                 recordCount = body.recordCount,
-                s3Bucket = targetS3Bucket,
+                s3Bucket = destinationS3Bucket,
                 embargoReleaseDate =
                   if (shouldEmbargo) embargoReleaseDate else None,
                 doi = doi.doi,

--- a/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
@@ -183,8 +183,8 @@ class PublishHandler(
               .getLatestVisibleVersion(publicDataset)
               .flatMap {
                 case Some(version) =>
-                  // TODO: rewrite this expression to be a more positive evaluation (improves readability)
-                  // TODO: may also need to reconsider this, given the check on Embargo Release Date in the past
+                  // if the current request is asking for embargo, and the latest published version is not under
+                  // embargo and the latest version is not unpublished, then the request is invalid and rejected.
                   if (requestedEmbargo && !version.underEmbargo && version.status != Unpublished) {
                     DBIO.failed(
                       ForbiddenException(

--- a/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
@@ -179,7 +179,7 @@ class PublishHandler(
             else
               DBIO.successful(())
 
-            latest <- PublicDatasetVersionsMapper
+            _ <- PublicDatasetVersionsMapper
               .getLatestVisibleVersion(publicDataset)
               .flatMap {
                 case Some(version) =>
@@ -212,6 +212,9 @@ class PublishHandler(
                 }
               }
             )
+
+            latest <- PublicDatasetVersionsMapper
+              .getLatestVisibleVersion(publicDataset)
 
             requestedWorkflow = body.workflowId.getOrElse(
               PublishingWorkflow.Version4

--- a/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
@@ -4,13 +4,25 @@ package com.pennsieve.discover.models
 
 class DoiRedirect(settings: WorkspaceSettings) {
   def getPublisher(): String = settings.publisherName
-  def getUrl(datasetId: Int, versionId: Int): String = {
+  private def getUrl(
+    templateUrl: String,
+    datasetId: Int,
+    versionId: Int
+  ): String = {
     val replacements = Map(
       "{{datasetId}}" -> datasetId.toString,
       "{{versionId}}" -> versionId.toString
     )
-    replacements.foldLeft(settings.redirectUrl)((a, b) => a.replace(b._1, b._2))
+    replacements.foldLeft(templateUrl)((a, b) => a.replace(b._1, b._2))
   }
+  def getDatasetUrl(datasetId: Int, versionId: Int): String =
+    getUrl(settings.redirectUrl, datasetId, versionId)
+  def getReleaseUrl(datasetId: Int, versionId: Int): String =
+    getUrl(
+      settings.redirectReleaseUrl.getOrElse(settings.redirectUrl),
+      datasetId,
+      versionId
+    )
 }
 
 object DoiRedirect {

--- a/server/src/main/scala/com/pennsieve/discover/models/PublishJobOutputs.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublishJobOutputs.scala
@@ -47,3 +47,36 @@ object ReleaseAction {
   implicit val decoder: Decoder[ReleaseAction] =
     deriveDecoder[ReleaseAction]
 }
+
+case class ReleaseActionV50(
+  sourceBucket: String,
+  sourceKey: String,
+  sourceSize: String,
+  sourceVersionId: String,
+  sourceEtag: String,
+  sourceSha256: String,
+  targetBucket: String,
+  targetKey: String,
+  targetSize: String,
+  targetVersionId: String,
+  targetEtag: String,
+  targetSha256: String
+)
+
+object ReleaseActionV50 {
+  implicit val encoder: Encoder[ReleaseActionV50] = deriveEncoder[ReleaseActionV50]
+  implicit val decoder: Decoder[ReleaseActionV50] = Decoder.forProduct12(
+    "source_bucket",
+    "source_key",
+    "source_size",
+    "source_version_id",
+    "source_etag",
+    "source_sha256",
+    "target_bucket",
+    "target_key",
+    "target_size",
+    "target_version_id",
+    "target_etag",
+    "target_sha256"
+  )(ReleaseActionV50.apply)
+}

--- a/server/src/main/scala/com/pennsieve/discover/models/PublishJobOutputs.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublishJobOutputs.scala
@@ -32,22 +32,6 @@ object PublishJobOutput {
     deriveDecoder[PublishJobOutput]
 }
 
-case class ReleaseAction(
-  sourceBucket: String,
-  sourceKey: String,
-  sourceVersion: String,
-  targetBucket: String,
-  targetKey: String,
-  targetVersion: String
-)
-
-object ReleaseAction {
-  implicit val encoder: Encoder[ReleaseAction] =
-    deriveEncoder[ReleaseAction]
-  implicit val decoder: Decoder[ReleaseAction] =
-    deriveDecoder[ReleaseAction]
-}
-
 case class ReleaseActionV50(
   sourceBucket: String,
   sourceKey: String,
@@ -64,7 +48,8 @@ case class ReleaseActionV50(
 )
 
 object ReleaseActionV50 {
-  implicit val encoder: Encoder[ReleaseActionV50] = deriveEncoder[ReleaseActionV50]
+  implicit val encoder: Encoder[ReleaseActionV50] =
+    deriveEncoder[ReleaseActionV50]
   implicit val decoder: Decoder[ReleaseActionV50] = Decoder.forProduct12(
     "source_bucket",
     "source_key",

--- a/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
@@ -9,6 +9,7 @@ case class WorkspaceSettings(
   organizationId: Int,
   publisherName: String,
   redirectUrl: String,
+  redirectReleaseUrl: Option[String] = None,
   createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
   updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
 )
@@ -19,7 +20,9 @@ object WorkspaceSettings {
     WorkspaceSettings(
       organizationId = 0,
       publisherName = defaultPublisher,
-      redirectUrl = s"${publicUrl}/datasets/{{datasetId}}/version/{{versionId}}"
+      redirectUrl = s"${publicUrl}/datasets/{{datasetId}}/version/{{versionId}}",
+      redirectReleaseUrl =
+        Some(s"${publicUrl}/code/{{datasetId}}/version/{{versionId}}")
     )
 
   val tupled = (this.apply _).tupled

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -39,7 +39,12 @@ import com.pennsieve.discover.server.definitions.{
 import com.pennsieve.discover.{ Authenticator, Ports, UnauthorizedException }
 import com.pennsieve.doi.client.definitions.PublishDoiRequest
 import com.pennsieve.doi.models.{ DoiDTO, DoiState }
-import com.pennsieve.models.{ DatasetMetadata, FileManifest, PublishStatus }
+import com.pennsieve.models.{
+  DatasetMetadata,
+  DatasetType,
+  FileManifest,
+  PublishStatus
+}
 import com.pennsieve.service.utilities.LogContext
 import io.circe.parser.decode
 import io.circe.syntax.EncoderOps
@@ -584,13 +589,23 @@ class SQSNotificationHandler(
         .map(_.getYear)
         .getOrElse(Calendar.getInstance().get(Calendar.YEAR))
 
+      doiRedirectUrl = publicDataset.datasetType match {
+        case DatasetType.Research =>
+          doiRedirect.getDatasetUrl(publicDataset.id, version.version)
+        case DatasetType.Release =>
+          doiRedirect.getReleaseUrl(publicDataset.id, version.version)
+        case _ =>
+          // TODO: do we need different values for Trial and Collection?
+          doiRedirect.getDatasetUrl(publicDataset.id, version.version)
+      }
+
       doi <- ports.doiClient.publishDoi(
         doi = version.doi,
         name = publicDataset.name,
         publicationYear = publicationYear,
         contributors = contributors,
         publisher = Some(doiRedirect.getPublisher()),
-        url = doiRedirect.getUrl(publicDataset.id, version.version),
+        url = doiRedirectUrl,
         owner = Some(
           InternalContributor(
             id = publicDataset.ownerId, //id is not used so the value does not matter

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -553,7 +553,7 @@ class SQSNotificationHandler(
     for {
       releaseResult <- ports.s3StreamClient.readReleaseResult(version)
       _ <- ports.db.run(
-        PublicFileVersionsMapper.updateManyReleases(version, releaseResult)
+        PublicFileVersionsMapper.updateReleasedFiles(version, releaseResult)
       )
 
     } yield ()

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -553,7 +553,7 @@ class SQSNotificationHandler(
     for {
       releaseResult <- ports.s3StreamClient.readReleaseResult(version)
       _ <- ports.db.run(
-        PublicFileVersionsMapper.updateManyS3Versions(version, releaseResult)
+        PublicFileVersionsMapper.updateManyReleases(version, releaseResult)
       )
 
     } yield ()

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -532,7 +532,13 @@ class SQSNotificationHandler(
           Future.successful(())
       }
 
-      // TODO: if migrated, then delete discover-release-results.json
+      // if migrated, then delete discover-release-results.json
+      _ = ports.config.runtimeSettings.deleteReleaseIntermediateFile match {
+        case true =>
+          ports.s3StreamClient.deleteReleaseResult(updatedVersion)
+        case false =>
+          Future.successful(true)
+      }
 
       _ <- ports.pennsieveApiClient
         .putPublishComplete(publishStatus, None)

--- a/server/src/test/resources/config-with-external-buckets.conf
+++ b/server/src/test/resources/config-with-external-buckets.conf
@@ -164,3 +164,8 @@ external-publish-buckets = [
         role-arn = "arn:aws:iam::999999999999:role/external-bucket-2-access-role"
     },
 ]
+
+runtime-settings = {
+    delete-release-intermediate-file = "false"
+    delete-release-intermediate-file = ${?DELETE_RELEASE_INTERMEDIATE_FILES}
+}

--- a/server/src/test/resources/config-without-external-buckets.conf
+++ b/server/src/test/resources/config-without-external-buckets.conf
@@ -153,3 +153,8 @@ athena {
     AwsCredentialsProviderClass = ${?AWS_CREDENTIALS_PROVIDER_CLASS}
   }
 }
+
+runtime-settings = {
+    delete-release-intermediate-file = "false"
+    delete-release-intermediate-file = ${?DELETE_RELEASE_INTERMEDIATE_FILES}
+}

--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -115,7 +115,8 @@ trait ServiceSpecHarness
           "sparc_glue_catalog.dev_s3_access_logs_db.discover",
         rejoinBucketAccessTable =
           "rejoin_glue_catalog.dev_s3_access_logs_db.discover"
-      )
+      ),
+      runtimeSettings = RuntimeSettings(deleteReleaseIntermediateFile = false)
     )
 
   def getPorts(config: Config): Ports = {

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -357,7 +357,9 @@ object TestUtilities extends AwaitableImplicits {
     path: String,
     fileType: String,
     size: Long = 100,
-    sourcePackageId: Option[String] = None
+    sourcePackageId: Option[String] = None,
+    s3VersionId: Option[String] = None,
+    sha256: Option[String] = None
   )(implicit
     executionContext: ExecutionContext
   ): PublicFileVersion =
@@ -370,10 +372,17 @@ object TestUtilities extends AwaitableImplicits {
             fileType = FileType.Text,
             sourcePackageId = None,
             s3VersionId = version.migrated match {
-              case true => Some(defaultS3VersionId)
+              case true =>
+                s3VersionId match {
+                  case Some(s3VersionId) => Some(s3VersionId)
+                  case None => Some(defaultS3VersionId)
+                }
               case false => None
             }
-          )
+          ).withSHA256(sha256 match {
+              case Some(sha256) => sha256
+              case None => ""
+            })
         )
       )
       .awaitFinite()

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
@@ -264,8 +264,8 @@ class MockS3StreamClient extends S3StreamClient {
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
-  ): Future[Unit] =
-    Future(
+  ): Future[Boolean] =
+    Future {
       releaseResults.remove(
         S3Key.Version(
           version.datasetId,
@@ -273,7 +273,8 @@ class MockS3StreamClient extends S3StreamClient {
           migrated = version.migrated
         )
       )
-    )
+      true
+    }
 
   def storeReleaseResults(
     version: PublicDatasetVersion,

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
@@ -14,6 +14,7 @@ import akka.util.ByteString
 import com.pennsieve.models.{
   DatasetMetadata,
   DatasetMetadataV4_0,
+  DatasetMetadataV5_0,
   FileManifest,
   FileType
 }
@@ -214,6 +215,9 @@ class MockS3StreamClient extends S3StreamClient {
   val publishMetadata: mutable.Map[S3Key.Version, DatasetMetadataV4_0] =
     mutable.Map.empty
 
+  val publishMetadataV5_0: mutable.Map[S3Key.Version, DatasetMetadataV5_0] =
+    mutable.Map.empty
+
   val releaseResults = List.empty[ReleaseAction]
 
   def withNextPublishResult(key: S3Key.Version, result: PublishJobOutput) =
@@ -224,6 +228,12 @@ class MockS3StreamClient extends S3StreamClient {
     metadata: DatasetMetadataV4_0
   ) =
     publishMetadata += key -> metadata
+
+  def withNextPublishMetadata(
+    key: S3Key.Version,
+    metadata: DatasetMetadataV5_0
+  ) =
+    publishMetadataV5_0 += key -> metadata
 
   def readPublishJobOutput(
     version: PublicDatasetVersion

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
@@ -259,6 +259,22 @@ class MockS3StreamClient extends S3StreamClient {
       )
     )
 
+  def deleteReleaseResult(
+    version: PublicDatasetVersion
+  )(implicit
+    system: ActorSystem,
+    ec: ExecutionContext
+  ): Future[Unit] =
+    Future(
+      releaseResults.remove(
+        S3Key.Version(
+          version.datasetId,
+          version = version.version,
+          migrated = version.migrated
+        )
+      )
+    )
+
   def storeReleaseResults(
     version: PublicDatasetVersion,
     results: List[ReleaseActionV50]

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
@@ -218,7 +218,8 @@ class MockS3StreamClient extends S3StreamClient {
   val publishMetadataV5_0: mutable.Map[S3Key.Version, DatasetMetadataV5_0] =
     mutable.Map.empty
 
-  val releaseResults = List.empty[ReleaseActionV50]
+  val releaseResults: mutable.Map[S3Key.Version, List[ReleaseActionV50]] =
+    mutable.Map.empty
 
   def withNextPublishResult(key: S3Key.Version, result: PublishJobOutput) =
     publishResults += key -> result
@@ -247,7 +248,33 @@ class MockS3StreamClient extends S3StreamClient {
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
-  ): Future[List[ReleaseActionV50]] = Future(releaseResults)
+  ): Future[List[ReleaseActionV50]] =
+    Future(
+      releaseResults(
+        S3Key.Version(
+          version.datasetId,
+          version = version.version,
+          migrated = version.migrated
+        )
+      )
+    )
+
+  def storeReleaseResults(
+    version: PublicDatasetVersion,
+    results: List[ReleaseActionV50]
+  )(implicit
+    system: ActorSystem,
+    ec: ExecutionContext
+  ): Future[Unit] =
+    Future(
+      releaseResults(
+        S3Key.Version(
+          version.datasetId,
+          version = version.version,
+          migrated = version.migrated
+        )
+      ) = results
+    )
 
   def deletePublishJobOutput(
     version: PublicDatasetVersion

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockS3StreamClient.scala
@@ -218,7 +218,7 @@ class MockS3StreamClient extends S3StreamClient {
   val publishMetadataV5_0: mutable.Map[S3Key.Version, DatasetMetadataV5_0] =
     mutable.Map.empty
 
-  val releaseResults = List.empty[ReleaseAction]
+  val releaseResults = List.empty[ReleaseActionV50]
 
   def withNextPublishResult(key: S3Key.Version, result: PublishJobOutput) =
     publishResults += key -> result
@@ -247,7 +247,7 @@ class MockS3StreamClient extends S3StreamClient {
   )(implicit
     system: ActorSystem,
     ec: ExecutionContext
-  ): Future[List[ReleaseAction]] = Future(releaseResults)
+  ): Future[List[ReleaseActionV50]] = Future(releaseResults)
 
   def deletePublishJobOutput(
     version: PublicDatasetVersion

--- a/server/src/test/scala/com/pennsieve/discover/models/DoiRedirectSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/models/DoiRedirectSpec.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+import org.scalatest.Suite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DoiRedirectSpec extends AnyWordSpec with Suite with Matchers {
+  val publicUrl = "https://discover.pennsieve.org"
+  val organizationId = 367
+  val organizationName = "SPARC"
+  val organizationUrl = "https://sparc.science"
+  val organizationRedirectUrlFormat =
+    s"${organizationUrl}/datasets/{{datasetId}}/version/{{versionId}}"
+  val organizationReleaseRedirectUrlFormat =
+    s"${organizationUrl}/code/{{datasetId}}/version/{{versionId}}"
+
+  val datasetId = 4
+  val versionId = 2
+
+  val releaseId = 3
+  val releaseVersion = 14
+
+  "DoiRedirect" should {
+    "provide defaults" in {
+      val doiRedirect = DoiRedirect(WorkspaceSettings.default(publicUrl))
+
+      doiRedirect.getDatasetUrl(datasetId, versionId) should startWith(
+        publicUrl
+      )
+    }
+
+    "provide workspace specifics" in {
+      val settings = WorkspaceSettings(
+        organizationId = organizationId,
+        publisherName = organizationName,
+        redirectUrl = organizationRedirectUrlFormat
+      )
+      val doiRedirect = DoiRedirect(settings)
+
+      doiRedirect.getDatasetUrl(datasetId, versionId) should startWith(
+        organizationUrl
+      )
+    }
+
+    "provide release redirect url" in {
+      val doiRedirect = DoiRedirect(WorkspaceSettings.default(publicUrl))
+
+      val releaseRedirectUrl =
+        doiRedirect.getReleaseUrl(releaseId, releaseVersion)
+      releaseRedirectUrl should startWith(publicUrl)
+      releaseRedirectUrl should endWith(
+        f"code/${releaseId}/version/${releaseVersion}"
+      )
+    }
+
+    "use dataset redirect url for release when not specified" in {
+      val settings = WorkspaceSettings(
+        organizationId = organizationId,
+        publisherName = organizationName,
+        redirectUrl = organizationRedirectUrlFormat
+      )
+      val doiRedirect = DoiRedirect(settings)
+
+      val releaseRedirectUrl =
+        doiRedirect.getReleaseUrl(releaseId, releaseVersion)
+      releaseRedirectUrl should startWith(organizationUrl)
+      releaseRedirectUrl should endWith(
+        f"datasets/${releaseId}/version/${releaseVersion}"
+      )
+    }
+
+    "use release redirect url for release when specified" in {
+      val settings = WorkspaceSettings(
+        organizationId = organizationId,
+        publisherName = organizationName,
+        redirectUrl = organizationRedirectUrlFormat,
+        redirectReleaseUrl = Some(organizationReleaseRedirectUrlFormat)
+      )
+      val doiRedirect = DoiRedirect(settings)
+
+      val releaseRedirectUrl =
+        doiRedirect.getReleaseUrl(releaseId, releaseVersion)
+      releaseRedirectUrl should startWith(organizationUrl)
+      releaseRedirectUrl should endWith(
+        f"code/${releaseId}/version/${releaseVersion}"
+      )
+    }
+  }
+}

--- a/server/src/test/scala/com/pennsieve/discover/models/JsonEncodingSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/models/JsonEncodingSpec.scala
@@ -507,5 +507,86 @@ class JsonEncodingSpec extends AnyWordSpec with Suite with Matchers {
       val decoded = decode[PublicDatasetDto](jsonString)
       decoded.isRight shouldBe true
     }
+
+    "decode a release result V5.0" in {
+      val jsonString =
+        s"""
+           |[
+           |  {
+           |    "source_bucket": "embargo-bucket",
+           |    "source_key": "5125/files/data/source-0.dat",
+           |    "source_size": "4742331076932",
+           |    "source_version_id": "Yu226jh9HZEZuPMm",
+           |    "source_etag": "IAOqXjhaztsG",
+           |    "source_sha256": "kp3MfoV3kWX2DO4uqOYj8hKo",
+           |    "target_bucket": "publish-bucket",
+           |    "target_key": "5125/files/data/source-0.dat",
+           |    "target_size": "4742331076932",
+           |    "target_version_id": "TeaY1sV7Vo000CKI",
+           |    "target_etag": "OEQR4Fn4JEis",
+           |    "target_sha256": "dr7bO3eVqee2jQvgnkEqqs8Q"
+           |  },
+           |  {
+           |    "source_bucket": "embargo-bucket",
+           |    "source_key": "5125/files/data/source-1.dat",
+           |    "source_size": "4178022176514",
+           |    "source_version_id": "1x76Keaufom9JsDr",
+           |    "source_etag": "Ybc9SKjarN0R",
+           |    "source_sha256": "2kvjORLN622LXoklC1jlqFsX",
+           |    "target_bucket": "publish-bucket",
+           |    "target_key": "5125/files/data/source-1.dat",
+           |    "target_size": "4178022176514",
+           |    "target_version_id": "V2dsjBzIDH6JZJ1q",
+           |    "target_etag": "w4Lymba4XTHr",
+           |    "target_sha256": "MMK6o4NKW0uSVsLlssvs9Anp"
+           |  },
+           |  {
+           |    "source_bucket": "embargo-bucket",
+           |    "source_key": "5125/files/data/source-2.dat",
+           |    "source_size": "1187153020914",
+           |    "source_version_id": "aNvPuGvNgJH2NNkB",
+           |    "source_etag": "EG4sjAuYnmHJ",
+           |    "source_sha256": "k8stpDnQaoI5zHwLyPCtSBQb",
+           |    "target_bucket": "publish-bucket",
+           |    "target_key": "5125/files/data/source-2.dat",
+           |    "target_size": "1187153020914",
+           |    "target_version_id": "eskZ6l7fA1CqUbDZ",
+           |    "target_etag": "IrlOHsEVYGON",
+           |    "target_sha256": "w5VmUCQ5WHs7wwNwRflcpCYB"
+           |  },
+           |  {
+           |    "source_bucket": "embargo-bucket",
+           |    "source_key": "5125/files/data/source-3.dat",
+           |    "source_size": "4009136485934",
+           |    "source_version_id": "I2KXz59q3S71ZA2E",
+           |    "source_etag": "POKIH8x3gvM3",
+           |    "source_sha256": "DVt9Dw8cI9b0gkRE8ioRmAfE",
+           |    "target_bucket": "publish-bucket",
+           |    "target_key": "5125/files/data/source-3.dat",
+           |    "target_size": "4009136485934",
+           |    "target_version_id": "fdmZRK9gw9SWR18x",
+           |    "target_etag": "nrzBmBt1E6oW",
+           |    "target_sha256": "s7o2bslcQANHkES64rwBy3gK"
+           |  },
+           |  {
+           |    "source_bucket": "embargo-bucket",
+           |    "source_key": "5125/files/data/source-4.dat",
+           |    "source_size": "78740955173",
+           |    "source_version_id": "es27PWaErvRWWADf",
+           |    "source_etag": "SebTFT8lNdp1",
+           |    "source_sha256": "NcEayL0VMeLWIb2bkMNGC3c1",
+           |    "target_bucket": "publish-bucket",
+           |    "target_key": "5125/files/data/source-4.dat",
+           |    "target_size": "78740955173",
+           |    "target_version_id": "funOSyUdSYYox51R",
+           |    "target_etag": "WIfHl2y3qrCG",
+           |    "target_sha256": "nR2Of7CBX7FsjzkyzgTFRqIU"
+           |  }
+           |]
+           |""".stripMargin
+
+      val decoded = decode[List[ReleaseActionV50]](jsonString)
+      decoded.isRight shouldBe true
+    }
   }
 }

--- a/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
@@ -664,15 +664,16 @@ class SQSNotificationHandlerSpec
       // create a file with path = {datasetId}/files/data/source.dat, S3 Version Id = x1, SHA256 = y1
       val path = "files/data/source.dat"
       val s3Key = s"${publicDataset.id}/${path}"
-      val publicFileVersionEmbargoed = TestUtilities.createFile(ports.db)(
-        publicDatasetVersion,
-        path,
-        FileType.GenericData.toString,
-        12345,
-        None,
-        Some("x1"),
-        Some("y1")
-      )
+      val publicFileVersionEmbargoed =
+        TestUtilities.createFileWithSha256(ports.db)(
+          publicDatasetVersion,
+          path,
+          FileType.GenericData.toString,
+          12345,
+          None,
+          Some("x1"),
+          "y1"
+        )
 
       // upload release results to Mock S3 Stream Client -
       //   path = {datasetId}/files/data/source.dat, S3 Version Id = x2, SHA256 = y2

--- a/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/notifications/SQSNotificationHandlerSpec.scala
@@ -32,7 +32,9 @@ import com.pennsieve.discover.models.{
   PublicFileVersion,
   PublishJobOutput,
   PublishingWorkflow,
+  ReleaseActionV50,
   S3Bucket,
+  S3Key,
   WorkspaceSettings
 }
 import com.pennsieve.discover.db.{
@@ -193,35 +195,35 @@ class SQSNotificationHandlerSpec
       )
 
       // pushing the DOI is now done asynchronously via separate SQS Message request
-//      val actualDoi: DoiDTO = ports.doiClient
-//        .asInstanceOf[MockDoiClient]
-//        .dois(doi.doi)
-//      actualDoi.title shouldBe Some(publicDataset.name)
-//      actualDoi.creators shouldBe Some(List())
-//      actualDoi.publicationYear shouldBe Some(futureYear)
-//      actualDoi.url shouldBe Some(
-//        s"https://discover.pennsieve.org/datasets/${publicDataset.id}/version/${publicDatasetV1.version}"
-//      )
+      //      val actualDoi: DoiDTO = ports.doiClient
+      //        .asInstanceOf[MockDoiClient]
+      //        .dois(doi.doi)
+      //      actualDoi.title shouldBe Some(publicDataset.name)
+      //      actualDoi.creators shouldBe Some(List())
+      //      actualDoi.publicationYear shouldBe Some(futureYear)
+      //      actualDoi.url shouldBe Some(
+      //        s"https://discover.pennsieve.org/datasets/${publicDataset.id}/version/${publicDatasetV1.version}"
+      //      )
 
       // indexing the published dataset is now done asynchronously via separate SQS Message request
-//      val (
-//        indexedVersion,
-//        indexedRevision,
-//        indexedSponsorship,
-//        indexedFiles,
-//        indexedRecords
-//      ) =
-//        ports.searchClient
-//          .asInstanceOf[MockSearchClient]
-//          .indexedDatasets(publicDataset.id)
-//
-//      indexedVersion.version shouldBe publicDatasetV1.version
-//      indexedRevision shouldBe None
-//      indexedSponsorship shouldBe None
-//
-//      // From defaults in MockS3StreamClient
-//      indexedFiles.length shouldBe 2
-//      indexedRecords.length shouldBe 1
+      //      val (
+      //        indexedVersion,
+      //        indexedRevision,
+      //        indexedSponsorship,
+      //        indexedFiles,
+      //        indexedRecords
+      //      ) =
+      //        ports.searchClient
+      //          .asInstanceOf[MockSearchClient]
+      //          .indexedDatasets(publicDataset.id)
+      //
+      //      indexedVersion.version shouldBe publicDatasetV1.version
+      //      indexedRevision shouldBe None
+      //      indexedSponsorship shouldBe None
+      //
+      //      // From defaults in MockS3StreamClient
+      //      indexedFiles.length shouldBe 2
+      //      indexedRecords.length shouldBe 1
     }
 
     "update publish status as failed" in {
@@ -293,76 +295,6 @@ class SQSNotificationHandlerSpec
         .state shouldBe Some(DoiState.Draft)
 
     }
-
-    // this test is invalid -- indexing is now done asynchronously via separate SQS message
-//    "not index files and records for embargoed datasets" in {
-//      val publicDataset =
-//        TestUtilities.createDataset(ports.db)()
-//
-//      val doi = ports.doiClient
-//        .asInstanceOf[MockDoiClient]
-//        .createMockDoi(
-//          publicDataset.sourceOrganizationId,
-//          publicDataset.sourceDatasetId
-//        )
-//
-//      val publicDatasetV1 = TestUtilities.createNewDatasetVersion(ports.db)(
-//        id = publicDataset.id,
-//        status = PublishStatus.EmbargoInProgress,
-//        doi = doi.doi
-//      )
-//
-//      // Successful publish jobs create an outputs.json file
-//      ports.s3StreamClient
-//        .asInstanceOf[MockS3StreamClient]
-//        .withNextPublishResult(
-//          publicDatasetV1.s3Key,
-//          PublishJobOutput(
-//            readmeKey = publicDatasetV1.s3Key / "readme.md",
-//            bannerKey = publicDatasetV1.s3Key / "banner.jpg",
-//            changelogKey = publicDatasetV1.s3Key / "changelog.md",
-//            totalSize = 76543
-//          )
-//        )
-//
-//      processNotification(
-//        PublishNotification(
-//          publicDataset.sourceOrganizationId,
-//          publicDataset.sourceDatasetId,
-//          PublishStatus.PublishSucceeded,
-//          publicDatasetV1.version
-//        )
-//      ) shouldBe an[MessageAction.Delete]
-//
-//      val publicVersion = ports.db
-//        .run(
-//          PublicDatasetVersionsMapper
-//            .getVersion(publicDatasetV1.datasetId, publicDatasetV1.version)
-//        )
-//        .awaitFinite()
-//
-//      inside(publicVersion) {
-//        case v: PublicDatasetVersion =>
-//          v.status shouldBe PublishStatus.EmbargoSucceeded
-//      }
-//
-//      val (
-//        indexedVersion,
-//        indexedRevision,
-//        indexedSponsorship,
-//        indexedFiles,
-//        indexedRecords
-//      ) =
-//        ports.searchClient
-//          .asInstanceOf[MockSearchClient]
-//          .indexedDatasets(publicDataset.id)
-//
-//      indexedVersion.version shouldBe publicDatasetV1.version
-//      indexedRevision shouldBe None
-//      indexedSponsorship shouldBe None
-//      indexedFiles shouldBe empty
-//      indexedRecords shouldBe empty
-//    }
 
     "update publish status as failed for embargoed datasets" in {
 
@@ -492,215 +424,304 @@ class SQSNotificationHandlerSpec
         .awaitFinite()
         .status shouldBe PublishStatus.NotPublished
     }
-  }
 
-  "release an embargoed dataset" in {
-    val datasetName = TestUtilities.randomString()
+    "release an embargoed dataset" in {
+      val datasetName = TestUtilities.randomString()
 
-    val publicDataset =
-      TestUtilities.createDataset(ports.db)(name = datasetName)
+      val publicDataset =
+        TestUtilities.createDataset(ports.db)(name = datasetName)
 
-    val doi = ports.doiClient
-      .asInstanceOf[MockDoiClient]
-      .createMockDoi(
-        publicDataset.sourceOrganizationId,
-        publicDataset.sourceDatasetId
+      val doi = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .createMockDoi(
+          publicDataset.sourceOrganizationId,
+          publicDataset.sourceDatasetId
+        )
+
+      val publicDatasetV1 = TestUtilities.createNewDatasetVersion(ports.db)(
+        id = publicDataset.id,
+        status = PublishStatus.ReleaseInProgress,
+        doi = doi.doi
       )
 
-    val publicDatasetV1 = TestUtilities.createNewDatasetVersion(ports.db)(
-      id = publicDataset.id,
-      status = PublishStatus.ReleaseInProgress,
-      doi = doi.doi
-    )
+      TestUtilities.createFile(ports.db)(
+        publicDatasetV1,
+        "files/test.txt",
+        "TEXT"
+      )
 
-    TestUtilities.createFile(ports.db)(
-      publicDatasetV1,
-      "files/test.txt",
-      "TEXT"
-    )
+      processNotification(
+        ReleaseNotification(
+          organizationId = publicDataset.sourceOrganizationId,
+          datasetId = publicDataset.sourceDatasetId,
+          version = publicDatasetV1.version,
+          publishBucket = S3Bucket("publish-bucket"),
+          embargoBucket = S3Bucket("embargo-bucket"),
+          success = true
+        )
+      ) shouldBe an[MessageAction.Delete]
 
-    processNotification(
-      ReleaseNotification(
+      val publicVersion = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getVersion(publicDatasetV1.datasetId, publicDatasetV1.version)
+        )
+        .awaitFinite()
+
+      // Update S3 bucket to be public bucket, not embargo bucket
+      publicVersion.s3Bucket shouldBe S3Bucket("publish-bucket")
+
+      ports.pennsieveApiClient
+        .asInstanceOf[MockPennsieveApiClient]
+        .publishCompleteRequests shouldBe List(
+        (
+          DatasetPublishStatus(
+            publicDataset.name,
+            publicDataset.sourceOrganizationId,
+            publicDataset.sourceDatasetId,
+            Some(publicDataset.id),
+            1,
+            PublishStatus.PublishSucceeded,
+            Some(publicVersion.createdAt),
+            workflowId = PublishingWorkflow.Version4
+          ),
+          None
+        )
+      )
+
+      val (
+        indexedVersion,
+        indexedRevision,
+        indexedSponsorship,
+        indexedFiles,
+        indexedRecords
+      ) =
+        ports.searchClient
+          .asInstanceOf[MockSearchClient]
+          .indexedDatasets(publicDataset.id)
+
+      indexedVersion.version shouldBe publicDatasetV1.version
+      indexedRevision shouldBe None
+      indexedSponsorship shouldBe None
+
+      // From defaults in MockS3StreamClient
+      indexedFiles.length shouldBe 1
+      indexedRecords.length shouldBe 1
+    }
+
+    "update release status as failed" in {
+
+      val datasetName = TestUtilities.randomString()
+
+      val publicDataset =
+        TestUtilities.createDataset(ports.db)(name = datasetName)
+
+      val doi = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .createMockDoi(
+          publicDataset.sourceOrganizationId,
+          publicDataset.sourceDatasetId
+        )
+
+      val publicDatasetV1 = TestUtilities.createNewDatasetVersion(ports.db)(
+        id = publicDataset.id,
+        status = PublishStatus.ReleaseInProgress,
+        doi = doi.doi
+      )
+
+      TestUtilities.createFile(ports.db)(
+        publicDatasetV1,
+        "files/test.txt",
+        "TEXT"
+      )
+
+      val releaseNotification = ReleaseNotification(
         organizationId = publicDataset.sourceOrganizationId,
         datasetId = publicDataset.sourceDatasetId,
         version = publicDatasetV1.version,
         publishBucket = S3Bucket("publish-bucket"),
         embargoBucket = S3Bucket("embargo-bucket"),
-        success = true
-      )
-    ) shouldBe an[MessageAction.Delete]
-
-    val publicVersion = ports.db
-      .run(
-        PublicDatasetVersionsMapper
-          .getVersion(publicDatasetV1.datasetId, publicDatasetV1.version)
-      )
-      .awaitFinite()
-
-    // Update S3 bucket to be public bucket, not embargo bucket
-    publicVersion.s3Bucket shouldBe S3Bucket("publish-bucket")
-
-    ports.pennsieveApiClient
-      .asInstanceOf[MockPennsieveApiClient]
-      .publishCompleteRequests shouldBe List(
-      (
-        DatasetPublishStatus(
-          publicDataset.name,
-          publicDataset.sourceOrganizationId,
-          publicDataset.sourceDatasetId,
-          Some(publicDataset.id),
-          1,
-          PublishStatus.PublishSucceeded,
-          Some(publicVersion.createdAt),
-          workflowId = PublishingWorkflow.Version4
-        ),
-        None
-      )
-    )
-
-    val (
-      indexedVersion,
-      indexedRevision,
-      indexedSponsorship,
-      indexedFiles,
-      indexedRecords
-    ) =
-      ports.searchClient
-        .asInstanceOf[MockSearchClient]
-        .indexedDatasets(publicDataset.id)
-
-    indexedVersion.version shouldBe publicDatasetV1.version
-    indexedRevision shouldBe None
-    indexedSponsorship shouldBe None
-
-    // From defaults in MockS3StreamClient
-    indexedFiles.length shouldBe 1
-    indexedRecords.length shouldBe 1
-  }
-
-  "update release status as failed" in {
-
-    val datasetName = TestUtilities.randomString()
-
-    val publicDataset =
-      TestUtilities.createDataset(ports.db)(name = datasetName)
-
-    val doi = ports.doiClient
-      .asInstanceOf[MockDoiClient]
-      .createMockDoi(
-        publicDataset.sourceOrganizationId,
-        publicDataset.sourceDatasetId
+        success = false,
+        Some("Error, error!")
       )
 
-    val publicDatasetV1 = TestUtilities.createNewDatasetVersion(ports.db)(
-      id = publicDataset.id,
-      status = PublishStatus.ReleaseInProgress,
-      doi = doi.doi
-    )
+      processNotification(releaseNotification) shouldBe an[MessageAction.Delete]
 
-    TestUtilities.createFile(ports.db)(
-      publicDatasetV1,
-      "files/test.txt",
-      "TEXT"
-    )
+      val publicVersion = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getVersion(publicDatasetV1.datasetId, publicDatasetV1.version)
+        )
+        .awaitFinite()
 
-    val releaseNotification = ReleaseNotification(
-      organizationId = publicDataset.sourceOrganizationId,
-      datasetId = publicDataset.sourceDatasetId,
-      version = publicDatasetV1.version,
-      publishBucket = S3Bucket("publish-bucket"),
-      embargoBucket = S3Bucket("embargo-bucket"),
-      success = false,
-      Some("Error, error!")
-    )
+      publicVersion.s3Bucket shouldBe S3Bucket("embargo-bucket")
+      publicVersion.status shouldBe PublishStatus.ReleaseFailed
 
-    processNotification(releaseNotification) shouldBe an[MessageAction.Delete]
-
-    val publicVersion = ports.db
-      .run(
-        PublicDatasetVersionsMapper
-          .getVersion(publicDatasetV1.datasetId, publicDatasetV1.version)
+      ports.pennsieveApiClient
+        .asInstanceOf[MockPennsieveApiClient]
+        .publishCompleteRequests shouldBe List(
+        (
+          DatasetPublishStatus(
+            publicDataset.name,
+            publicDataset.sourceOrganizationId,
+            publicDataset.sourceDatasetId,
+            Some(publicDataset.id),
+            0,
+            PublishStatus.ReleaseFailed,
+            Some(publicVersion.createdAt),
+            workflowId = PublishingWorkflow.Version4
+          ),
+          Some(s"Version ${publicVersion.version} failed to release")
+        )
       )
-      .awaitFinite()
+    }
 
-    publicVersion.s3Bucket shouldBe S3Bucket("embargo-bucket")
-    publicVersion.status shouldBe PublishStatus.ReleaseFailed
+    "periodically notify Pennsieve API to start release workflow" in {
+      val version1 =
+        TestUtilities.createDatasetV1(ports.db)(
+          sourceOrganizationId = 1,
+          sourceDatasetId = 3,
+          status = PublishStatus.EmbargoSucceeded,
+          embargoReleaseDate = Some(LocalDate.now)
+        )
 
-    ports.pennsieveApiClient
-      .asInstanceOf[MockPennsieveApiClient]
-      .publishCompleteRequests shouldBe List(
-      (
-        DatasetPublishStatus(
-          publicDataset.name,
-          publicDataset.sourceOrganizationId,
-          publicDataset.sourceDatasetId,
-          Some(publicDataset.id),
-          0,
-          PublishStatus.ReleaseFailed,
-          Some(publicVersion.createdAt),
-          workflowId = PublishingWorkflow.Version4
-        ),
-        Some(s"Version ${publicVersion.version} failed to release")
-      )
-    )
-  }
+      val version2 =
+        TestUtilities.createDatasetV1(ports.db)(
+          sourceOrganizationId = 1,
+          sourceDatasetId = 5,
+          status = PublishStatus.PublishSucceeded,
+          embargoReleaseDate = Some(LocalDate.now)
+        )
 
-  "periodically notify Pennsieve API to start release workflow" in {
-    val version1 =
+      processNotification(ScanForReleaseNotification()) shouldBe an[
+        MessageAction.Delete
+      ]
+
+      ports.pennsieveApiClient
+        .asInstanceOf[MockPennsieveApiClient]
+        .startReleaseRequests shouldBe List((1, 3))
+    }
+
+    "start release workflow for datasets with release dates in the past" in {
       TestUtilities.createDatasetV1(ports.db)(
         sourceOrganizationId = 1,
         sourceDatasetId = 3,
         status = PublishStatus.EmbargoSucceeded,
-        embargoReleaseDate = Some(LocalDate.now)
+        embargoReleaseDate = Some(LocalDate.now.minusWeeks(1))
       )
 
-    val version2 =
+      processNotification(ScanForReleaseNotification()) shouldBe an[
+        MessageAction.Delete
+      ]
+
+      ports.pennsieveApiClient
+        .asInstanceOf[MockPennsieveApiClient]
+        .startReleaseRequests shouldBe List((1, 3))
+    }
+
+    "do not start release workflow for datasets with release dates in the future" in {
       TestUtilities.createDatasetV1(ports.db)(
-        sourceOrganizationId = 1,
-        sourceDatasetId = 5,
-        status = PublishStatus.PublishSucceeded,
-        embargoReleaseDate = Some(LocalDate.now)
+        status = PublishStatus.EmbargoSucceeded,
+        embargoReleaseDate = Some(LocalDate.now.plusDays(1))
       )
 
-    processNotification(ScanForReleaseNotification()) shouldBe an[
-      MessageAction.Delete
-    ]
+      processNotification(ScanForReleaseNotification()) shouldBe an[
+        MessageAction.Delete
+      ]
 
-    ports.pennsieveApiClient
-      .asInstanceOf[MockPennsieveApiClient]
-      .startReleaseRequests shouldBe List((1, 3))
-  }
+      ports.pennsieveApiClient
+        .asInstanceOf[MockPennsieveApiClient]
+        .startReleaseRequests shouldBe empty
+    }
 
-  "start release workflow for datasets with release dates in the past" in {
-    TestUtilities.createDatasetV1(ports.db)(
-      sourceOrganizationId = 1,
-      sourceDatasetId = 3,
-      status = PublishStatus.EmbargoSucceeded,
-      embargoReleaseDate = Some(LocalDate.now.minusWeeks(1))
-    )
+    "update S3 Version Id and SHA256 when release completes" in {
+      val sourceOrganizationId = 1
+      val sourceDatasetId = 15
 
-    processNotification(ScanForReleaseNotification()) shouldBe an[
-      MessageAction.Delete
-    ]
+      // create a dataset
+      val publicDataset =
+        TestUtilities.createDataset(ports.db)(
+          sourceOrganizationId = sourceOrganizationId,
+          sourceDatasetId = sourceDatasetId
+        )
 
-    ports.pennsieveApiClient
-      .asInstanceOf[MockPennsieveApiClient]
-      .startReleaseRequests shouldBe List((1, 3))
-  }
+      // create a dataset version, status = EmbargoSucceeded
+      val doi = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .createMockDoi(
+          publicDataset.sourceOrganizationId,
+          publicDataset.sourceDatasetId
+        )
 
-  "do not start release workflow for datasets with release dates in the future" in {
-    TestUtilities.createDatasetV1(ports.db)(
-      status = PublishStatus.EmbargoSucceeded,
-      embargoReleaseDate = Some(LocalDate.now.plusDays(1))
-    )
+      val publicDatasetVersion =
+        TestUtilities.createNewDatasetVersion(ports.db)(
+          id = publicDataset.id,
+          status = PublishStatus.EmbargoSucceeded,
+          doi = doi.doi,
+          migrated = true
+        )
 
-    processNotification(ScanForReleaseNotification()) shouldBe an[
-      MessageAction.Delete
-    ]
+      // create a file with path = {datasetId}/files/data/source.dat, S3 Version Id = x1, SHA256 = y1
+      val path = "files/data/source.dat"
+      val s3Key = s"${publicDataset.id}/${path}"
+      val publicFileVersionEmbargoed = TestUtilities.createFile(ports.db)(
+        publicDatasetVersion,
+        path,
+        FileType.GenericData.toString,
+        12345,
+        None,
+        Some("x1"),
+        Some("y1")
+      )
 
-    ports.pennsieveApiClient
-      .asInstanceOf[MockPennsieveApiClient]
-      .startReleaseRequests shouldBe empty
+      // upload release results to Mock S3 Stream Client -
+      //   path = {datasetId}/files/data/source.dat, S3 Version Id = x2, SHA256 = y2
+      val results = List(
+        ReleaseActionV50(
+          sourceBucket = "embargo-bucket",
+          sourceKey = s3Key,
+          sourceSize = "12345",
+          sourceVersionId = "x1",
+          sourceEtag = "none",
+          sourceSha256 = "y1",
+          targetBucket = "bucket",
+          targetKey = s3Key,
+          targetSize = "12345",
+          targetVersionId = "x2",
+          targetEtag = "none",
+          targetSha256 = "y2"
+        )
+      )
+      val _ = ports.s3StreamClient
+        .asInstanceOf[MockS3StreamClient]
+        .storeReleaseResults(publicDatasetVersion, results)
+        .await
+
+      // processNotification(...)
+      processNotification(
+        ReleaseNotification(
+          organizationId = sourceOrganizationId,
+          datasetId = sourceDatasetId,
+          version = publicDatasetVersion.version,
+          publishBucket = S3Bucket("bucket"),
+          embargoBucket = S3Bucket("embargo-bucket"),
+          success = true,
+          error = None
+        )
+      ) shouldBe an[MessageAction.Delete]
+
+      // get PublicFileVersion
+      val publicFileVersionReleased = ports.db
+        .run(
+          PublicFileVersionsMapper
+            .getFileVersion(publicDataset.id, S3Key.File(s3Key), "x2")
+        )
+        .await
+
+      // check S3 Version Id and SHA256
+      publicFileVersionReleased.s3Version shouldBe ("x2")
+      publicFileVersionReleased.sha256.get shouldBe ("y2")
+    }
   }
 
   "Discover Service SQS Queue Handler" should {

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -200,7 +200,9 @@ data "aws_iam_policy_document" "iam_policy_document" {
       data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn,
       "${data.terraform_remote_state.platform_infrastructure.outputs.precision_publish50_bucket_arn}/*",
       data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn,
-      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn}/*"
+      "${data.terraform_remote_state.platform_infrastructure.outputs.precision_embargo50_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn}/*",
     ]
   }
 

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -347,3 +347,10 @@ resource "aws_ssm_parameter" "rejoin_bucket_access_glue_table" {
 #   type  = "String"
 #   value = data.terraform_remote_state.account.outputs.data_management_victor_ops_sns_topic_id
 # }
+
+// Runtime settings
+resource "aws_ssm_parameter" "delete_release_intermediate_file" {
+  name = "/${var.environment_name}/${var.service_name}/delete-release-intermediate-file"
+  type = "String"
+  value = "false"
+}

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -276,6 +276,19 @@ resource "aws_ssm_parameter" "sparc_bucket_role_arn" {
   type  = "String"
   value = data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn
 }
+
+resource "aws_ssm_parameter" "awsod_sparc_publish_50_bucket" {
+  name  = "/${var.environment_name}/${var.service_name}/awsod-sparc-publish-50-bucket"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_id
+}
+
+resource "aws_ssm_parameter" "awsod_sparc_bucket_role_arn" {
+  name  = "/${var.environment_name}/${var.service_name}/awsod-sparc-bucket-role-arn"
+  type  = "String"
+  value = data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_bucket_role_arn
+}
+
 //    RE-JOIN
 resource "aws_ssm_parameter" "rejoin_publish_50_bucket" {
   name  = "/${var.environment_name}/${var.service_name}/rejoin-publish-50-bucket"


### PR DESCRIPTION
This pull request implements the following changes in the Discover Service.

- grant permission on AWS Open Data S3 Buckets (for SPARC)
- use the same S3 Bucket for all versions of a public dataset
- provide ability to specify a DOI redirect URL for code repos (releases) in Workspace Settings
- provide default DOI redirect URL for code repos for Pennsieve Discover
- fix support for Discover Release V5.0, and for capturing SHA256 of copied files
- conditionally delete release intermediate file (controlled by a Config setting)