### PR TITLE
Discover Service Updates - Sprint 83

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -729,17 +729,26 @@ class AlpakkaS3StreamClient(
       _ = logger.debug(
         s"revision: copying banner, readme and changelog to frontend bucket ${frontendBucket.value}"
       )
+
+      // generate new key. with migrated = false to force the path to contain the version id
+      keyFrontend = S3Key.Revision(
+        dataset.id,
+        version.version,
+        revision.revision,
+        false
+      )
+
       _ <- copyPresignedUrlToFrontendBucket(
         bannerPresignedUrl,
-        key / newNameSameExtension(bannerPresignedUrl, BANNER)
+        keyFrontend / newNameSameExtension(bannerPresignedUrl, BANNER)
       )
       _ <- copyPresignedUrlToFrontendBucket(
         readmePresignedUrl,
-        key / newNameSameExtension(readmePresignedUrl, README)
+        keyFrontend / newNameSameExtension(readmePresignedUrl, README)
       )
       _ <- copyPresignedUrlToFrontendBucket(
         changelogPresignedUrl,
-        key / newNameSameExtension(changelogPresignedUrl, CHANGELOG)
+        keyFrontend / newNameSameExtension(changelogPresignedUrl, CHANGELOG)
       )
       _ = logger.debug(
         s"revision: copied banner, readme and changelog to frontend bucket ${frontendBucket.value}"

--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -663,8 +663,8 @@ class AlpakkaS3StreamClient(
     )
 
     // Remove the empty file field
-    implicit val encoder: Encoder[DatasetMetadataV4_0] =
-      deriveEncoder[DatasetMetadataV4_0].mapJson(_.mapObject(_.remove("files")))
+    implicit val encoder: Encoder[DatasetMetadataV5_0] =
+      deriveEncoder[DatasetMetadataV5_0].mapJson(_.mapObject(_.remove("files")))
 
     // Remove null fields when printing
     val bytes = ByteString(

--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -620,7 +620,7 @@ class AlpakkaS3StreamClient(
     ec: ExecutionContext
   ): Future[NewFiles] = {
 
-    val metadata = DatasetMetadataV4_0(
+    val metadata = DatasetMetadataV5_0(
       pennsieveDatasetId = dataset.id,
       version = version.version,
       revision = Some(revision.revision),

--- a/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/DoiRedirect.scala
@@ -2,7 +2,7 @@
 
 package com.pennsieve.discover.models
 
-class DoiRedirect(settings: WorkspaceSettings) {
+class DoiRedirect(settings: RedirectSettings) {
   def getPublisher(): String = settings.publisherName
   private def getUrl(
     templateUrl: String,
@@ -18,14 +18,10 @@ class DoiRedirect(settings: WorkspaceSettings) {
   def getDatasetUrl(datasetId: Int, versionId: Int): String =
     getUrl(settings.redirectUrl, datasetId, versionId)
   def getReleaseUrl(datasetId: Int, versionId: Int): String =
-    getUrl(
-      settings.redirectReleaseUrl.getOrElse(settings.redirectUrl),
-      datasetId,
-      versionId
-    )
+    getUrl(settings.redirectReleaseUrl, datasetId, versionId)
 }
 
 object DoiRedirect {
-  def apply(settings: WorkspaceSettings): DoiRedirect =
+  def apply(settings: RedirectSettings): DoiRedirect =
     new DoiRedirect(settings)
 }

--- a/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
@@ -4,6 +4,21 @@ package com.pennsieve.discover.models
 
 import java.time.{ OffsetDateTime, ZoneOffset }
 
+case class RedirectSettings(
+  publisherName: String,
+  redirectUrl: String,
+  redirectReleaseUrl: String
+)
+
+object RedirectSettings {
+  def apply(defaults: WorkspaceSettings): RedirectSettings = RedirectSettings(
+    publisherName = defaults.publisherName,
+    redirectUrl = defaults.redirectUrl,
+    redirectReleaseUrl =
+      defaults.redirectReleaseUrl.getOrElse(WorkspaceSettings.defaultUrl)
+  )
+}
+
 case class WorkspaceSettings(
   id: Int = 0,
   organizationId: Int,
@@ -12,10 +27,20 @@ case class WorkspaceSettings(
   redirectReleaseUrl: Option[String] = None,
   createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
   updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
-)
+) {
+  def +(defaults: WorkspaceSettings): RedirectSettings =
+    RedirectSettings(
+      publisherName = publisherName,
+      redirectUrl = redirectUrl,
+      redirectReleaseUrl = redirectReleaseUrl.getOrElse(
+        defaults.redirectReleaseUrl.getOrElse(WorkspaceSettings.defaultUrl)
+      )
+    )
+}
 
 object WorkspaceSettings {
   def defaultPublisher = "Pennsieve Discover"
+  def defaultUrl = "https://discover.pennsieve.io"
   def default(publicUrl: String): WorkspaceSettings =
     WorkspaceSettings(
       organizationId = 0,

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -578,10 +578,14 @@ class SQSNotificationHandler(
           .getSettings(organizationId = publicDataset.sourceOrganizationId)
       )
 
-      doiRedirect = DoiRedirect(
-        workspaceSettings
-          .getOrElse(WorkspaceSettings.default(ports.config.publicUrl))
-      )
+      redirectSettings = workspaceSettings match {
+        case Some(workspaceSettings) =>
+          workspaceSettings + WorkspaceSettings.default(ports.config.publicUrl)
+        case None =>
+          RedirectSettings(WorkspaceSettings.default(ports.config.publicUrl))
+      }
+
+      doiRedirect = DoiRedirect(redirectSettings)
 
       token = Authenticator.generateServiceToken(
         ports.jwt,

--- a/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/S3StreamClientSpec.scala
@@ -582,12 +582,12 @@ class S3StreamClientSpec
 
       // However, not having "files" makes decoding the dataset metadata a little painful.
       // TODO: make "files" optional in the root case class and remove this.
-      implicit val decoder: Decoder[DatasetMetadataV4_0] =
-        deriveDecoder[DatasetMetadataV4_0].prepare(
+      implicit val decoder: Decoder[DatasetMetadataV5_0] =
+        deriveDecoder[DatasetMetadataV5_0].prepare(
           _.withFocus(_.mapObject(_.add("files", List.empty[String].asJson)))
         )
 
-      decode[DatasetMetadataV4_0](manifest).value shouldBe DatasetMetadataV4_0(
+      decode[DatasetMetadataV5_0](manifest).value shouldBe DatasetMetadataV5_0(
         pennsieveDatasetId = 3,
         version = 4,
         revision = Some(5),

--- a/server/src/test/scala/com/pennsieve/discover/models/DoiRedirectSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/models/DoiRedirectSpec.scala
@@ -22,70 +22,63 @@ class DoiRedirectSpec extends AnyWordSpec with Suite with Matchers {
   val releaseId = 3
   val releaseVersion = 14
 
+  lazy val defaultSettings = WorkspaceSettings.default(publicUrl)
+
   "DoiRedirect" should {
     "provide defaults" in {
-      val doiRedirect = DoiRedirect(WorkspaceSettings.default(publicUrl))
+      val doiRedirect = DoiRedirect(RedirectSettings(defaultSettings))
 
-      doiRedirect.getDatasetUrl(datasetId, versionId) should startWith(
-        publicUrl
-      )
+      val datasetUrl = doiRedirect.getDatasetUrl(datasetId, versionId)
+      datasetUrl should startWith(publicUrl)
+      datasetUrl should endWith(f"datasets/${datasetId}/version/${versionId}")
+
+      val releaseUrl = doiRedirect.getReleaseUrl(releaseId, releaseVersion)
+      releaseUrl should startWith(publicUrl)
+      releaseUrl should endWith(f"code/${releaseId}/version/${releaseVersion}")
     }
 
-    "provide workspace specifics" in {
-      val settings = WorkspaceSettings(
-        organizationId = organizationId,
-        publisherName = organizationName,
-        redirectUrl = organizationRedirectUrlFormat
-      )
-      val doiRedirect = DoiRedirect(settings)
-
-      doiRedirect.getDatasetUrl(datasetId, versionId) should startWith(
-        organizationUrl
-      )
-    }
-
-    "provide release redirect url" in {
-      val doiRedirect = DoiRedirect(WorkspaceSettings.default(publicUrl))
-
-      val releaseRedirectUrl =
-        doiRedirect.getReleaseUrl(releaseId, releaseVersion)
-      releaseRedirectUrl should startWith(publicUrl)
-      releaseRedirectUrl should endWith(
-        f"code/${releaseId}/version/${releaseVersion}"
-      )
-    }
-
-    "use dataset redirect url for release when not specified" in {
-      val settings = WorkspaceSettings(
-        organizationId = organizationId,
-        publisherName = organizationName,
-        redirectUrl = organizationRedirectUrlFormat
-      )
-      val doiRedirect = DoiRedirect(settings)
-
-      val releaseRedirectUrl =
-        doiRedirect.getReleaseUrl(releaseId, releaseVersion)
-      releaseRedirectUrl should startWith(organizationUrl)
-      releaseRedirectUrl should endWith(
-        f"datasets/${releaseId}/version/${releaseVersion}"
-      )
-    }
-
-    "use release redirect url for release when specified" in {
-      val settings = WorkspaceSettings(
+    "provide workspace-specific dataset url" in {
+      val workspaceSettings = WorkspaceSettings(
         organizationId = organizationId,
         publisherName = organizationName,
         redirectUrl = organizationRedirectUrlFormat,
         redirectReleaseUrl = Some(organizationReleaseRedirectUrlFormat)
       )
-      val doiRedirect = DoiRedirect(settings)
 
-      val releaseRedirectUrl =
-        doiRedirect.getReleaseUrl(releaseId, releaseVersion)
-      releaseRedirectUrl should startWith(organizationUrl)
-      releaseRedirectUrl should endWith(
-        f"code/${releaseId}/version/${releaseVersion}"
+      val doiRedirect = DoiRedirect(workspaceSettings + defaultSettings)
+
+      val datasetUrl = doiRedirect.getDatasetUrl(datasetId, versionId)
+      datasetUrl should startWith(organizationUrl)
+      datasetUrl should endWith(f"datasets/${datasetId}/version/${versionId}")
+    }
+
+    "provide workspace-specific release url" in {
+      val workspaceSettings = WorkspaceSettings(
+        organizationId = organizationId,
+        publisherName = organizationName,
+        redirectUrl = organizationRedirectUrlFormat,
+        redirectReleaseUrl = Some(organizationReleaseRedirectUrlFormat)
       )
+
+      val doiRedirect = DoiRedirect(workspaceSettings + defaultSettings)
+
+      val releaseUrl = doiRedirect.getReleaseUrl(releaseId, releaseVersion)
+      releaseUrl should startWith(organizationUrl)
+      releaseUrl should endWith(f"code/${releaseId}/version/${releaseVersion}")
+    }
+
+    "use default redirect url for release when not specified in WorkspaceSettings" in {
+      val workspaceSettings = WorkspaceSettings(
+        organizationId = organizationId,
+        publisherName = organizationName,
+        redirectUrl = organizationRedirectUrlFormat
+      )
+
+      val doiRedirect = DoiRedirect(workspaceSettings + defaultSettings)
+
+      val releaseUrl = doiRedirect.getReleaseUrl(releaseId, releaseVersion)
+      releaseUrl should startWith(publicUrl)
+      releaseUrl should endWith(f"code/${releaseId}/version/${releaseVersion}")
     }
   }
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -239,7 +239,8 @@ data "aws_iam_policy_document" "iam_policy_document" {
     actions = ["sts:AssumeRole"]
     resources = [
       data.terraform_remote_state.platform_infrastructure.outputs.sparc_bucket_role_arn,
-      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn
+      data.terraform_remote_state.platform_infrastructure.outputs.rejoin_bucket_role_arn,
+      data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_bucket_role_arn,
     ]
   }
 


### PR DESCRIPTION
Implements or addresses these tickets and tasks:
- [Fix revision destination S3 Key on Discover Frontend Bucket](https://app.clickup.com/t/868d0wz5v)
- [generate **Dataset Metadata V5.0** on Revision](https://app.clickup.com/t/868d3a8qk)
- [update IAM Policy to permit `sts:AssumeRole` into the AWS Open Data Account](https://app.clickup.com/t/868d1fxnu)
- [Code Repo DOI redirect URLs default to Pennsieve Discover (unless specifically customized by workspace)](https://app.clickup.com/t/868d48m3r)
