### PR TITLE
Add /datasets/doi endpoint

### DIFF
--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -200,6 +200,8 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/DatasetsByDOIRequest"
+        description: list of DOIs
+        required: true
       responses:
         "200":
           description: successful operation
@@ -1880,8 +1882,16 @@ components:
 
     DatasetsByDOIResponse:
       type: object
+      required:
+        - published
+        - embargoed
+        - unpublished
       properties:
         published:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/PublicDatasetDTO"
+        embargoed:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/PublicDatasetDTO"

--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -211,6 +211,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DatasetsByDOIResponse"
+        "400":
+          description: bad request if no DOIs are included
+          content:
+            application/json:
+              schema:
+                type: string
 
   "/datasets/{datasetId}/preview":
     post:

--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -15,7 +15,7 @@ tags:
   - name: Datasets
   - name: Tags
   - name: Search
-  - name: Packages 
+  - name: Packages
   - name: Metrics
 
 paths:
@@ -23,7 +23,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: get the latest published version of each dataset
       operationId: getDatasets
       x-scala-package: dataset
@@ -100,7 +100,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: get the latest version of a dataset
       operationId: getDataset
       x-scala-package: dataset
@@ -142,7 +142,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: get a dataset by DOI
       description: |
         Find a Pennsieve dataset by DOI
@@ -185,11 +185,34 @@ paths:
               schema:
                 $ref: "#/components/schemas/TombstoneDTO"
 
+  "/datasets/doi":
+    get:
+      tags:
+        - Datasets
+      security: [ ]
+      summary: get datasets by DOIs
+      description: |
+        Find Pennsieve datasets by DOI
+      operationId: getDatasetsByDoi
+      x-scala-package: dataset
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DatasetsByDOIRequest"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DatasetsByDOIResponse"
+
   "/datasets/{datasetId}/preview":
     post:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: request preview access to a dataset
       operationId: requestPreview
       x-scala-package: dataset
@@ -228,7 +251,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: get all published versions of a dataset
       operationId: getDatasetVersions
       x-scala-package: dataset
@@ -260,7 +283,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: get a dataset by version
       operationId: getDatasetVersion
       x-scala-package: dataset
@@ -303,7 +326,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: get a file from a dataset
       operationId: getFile
       x-scala-package: dataset
@@ -364,7 +387,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: download the dataset as a ZIP archive
       operationId: downloadDatasetVersion
       x-scala-package: dataset
@@ -413,7 +436,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: download the metadata of the dataset
       operationId: getDatasetMetadata
       x-scala-package: dataset
@@ -461,7 +484,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: view files for a dataset
       operationId: browseFiles
       x-scala-package: dataset
@@ -601,7 +624,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: view release assets for a dataset
       operationId: browseAssets
       x-scala-package: dataset
@@ -682,7 +705,7 @@ paths:
     post:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: get a manifest of files to be downloaded for a dataset
       operationId: downloadManifest
       x-scala-package: dataset
@@ -754,7 +777,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: get the data use agreement for this dataset, if under embargo
       operationId: getDataUseAgreement
       x-scala-package: dataset
@@ -792,7 +815,7 @@ paths:
     get:
       tags:
         - Datasets
-      security: []
+      security: [ ]
       summary: download the data use agreement for this dataset, if under embargo
       operationId: downloadDataUseAgreement
       x-scala-package: dataset
@@ -827,7 +850,7 @@ paths:
     get:
       tags:
         - Tags
-      security: []
+      security: [ ]
       summary: get all dataset tags
       operationId: getTags
       x-scala-package: tag
@@ -845,7 +868,7 @@ paths:
     get:
       tags:
         - Search
-      security: []
+      security: [ ]
       summary: get datasets matching criteria
       operationId: searchDatasets
       x-scala-package: search
@@ -920,7 +943,7 @@ paths:
     get:
       tags:
         - Search
-      security: []
+      security: [ ]
       summary: get files matching criteria
       operationId: searchFiles
       x-scala-package: search
@@ -985,7 +1008,7 @@ paths:
     get:
       tags:
         - Metrics
-      security: []
+      security: [ ]
       summary: "Get Organization Dataset Metrics"
       operationId: getOrganizationDatasetMetrics
       x-scala-package: organization
@@ -1015,7 +1038,7 @@ paths:
     get:
       tags:
         - Search
-      security: []
+      security: [ ]
       summary: get records matching criteria
       operationId: searchRecords
       x-scala-package: search
@@ -1067,40 +1090,40 @@ paths:
     get:
       tags:
         - Packages
-      security: []
+      security: [ ]
       summary: get the files from the sourcePackageId of a package
       operationId: getFileFromSourcePackageId
       x-scala-package: file
       parameters:
-      - name: sourcePackageId
-        in: path
-        description: source package id
-        required: true
-        schema:
-          type: string
-      - name: limit
-        in: query
-        description: max number of files returned
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 100
-      - name: offset
-        in: query
-        description: offset used for pagination of results
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
+        - name: sourcePackageId
+          in: path
+          description: source package id
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: max number of files returned
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 100
+        - name: offset
+          in: query
+          description: offset used for pagination of results
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
       responses:
         "200":
           description: successful operation
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/FileTreeWithOrgPage"
+                $ref: "#/components/schemas/FileTreeWithOrgPage"
         "404":
           description: resource not found
           content:
@@ -1112,28 +1135,28 @@ paths:
     get:
       tags:
         - Metrics
-      security: []
+      security: [ ]
       summary: metrics
       operationId: getDatasetDownloadsSummary
       x-scala-package: metrics
       description: get the dataset downloads summary for the requested date range
       parameters:
-      - name: startDate
-        in: query
-        description: Date for the beginning of download metrics
-        required: true
-        schema:
-          type: string
-          format: date
-          nullable: true
-      - name: endDate
-        in: query
-        description: Date for the end of download metrics
-        required: true
-        schema:
-          type: string
-          format: date
-          nullable: true
+        - name: startDate
+          in: query
+          description: Date for the beginning of download metrics
+          required: true
+          schema:
+            type: string
+            format: date
+            nullable: true
+        - name: endDate
+          in: query
+          description: Date for the end of download metrics
+          required: true
+          schema:
+            type: string
+            format: date
+            nullable: true
       responses:
         "200":
           description: successful operation
@@ -1670,8 +1693,8 @@ components:
     PublicCollectionDTO:
       type: object
       required:
-      - id
-      - name
+        - id
+        - name
       properties:
         id:
           type: integer
@@ -1682,8 +1705,8 @@ components:
     PublicExternalPublicationDTO:
       type: object
       required:
-      - doi
-      - relationshipType
+        - doi
+        - relationshipType
       properties:
         doi:
           type: string
@@ -1844,3 +1867,25 @@ components:
         downloads:
           type: integer
           format: int32
+
+    DatasetsByDOIRequest:
+      type: object
+      required:
+        - dois
+      properties:
+        dois:
+          type: array
+          items:
+            type: string
+
+    DatasetsByDOIResponse:
+      type: object
+      properties:
+        published:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/PublicDatasetDTO"
+        unpublished:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/TombstoneDTO"

--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -1884,7 +1884,6 @@ components:
       type: object
       required:
         - published
-        - embargoed
         - unpublished
       properties:
         published:

--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -1890,10 +1890,6 @@ components:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/PublicDatasetDTO"
-        embargoed:
-          type: object
-          additionalProperties:
-            $ref: "#/components/schemas/PublicDatasetDTO"
         unpublished:
           type: object
           additionalProperties:

--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -195,13 +195,15 @@ paths:
         Find Pennsieve datasets by DOI
       operationId: getDatasetsByDoi
       x-scala-package: dataset
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/DatasetsByDOIRequest"
-        description: list of DOIs
-        required: true
+      parameters:
+        - name: doi
+          in: query
+          description: DOI list; Pennsieve DOI prefix - 10.26275
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         "200":
           description: successful operation
@@ -1869,16 +1871,6 @@ components:
         downloads:
           type: integer
           format: int32
-
-    DatasetsByDOIRequest:
-      type: object
-      required:
-        - dois
-      properties:
-        dois:
-          type: array
-          items:
-            type: string
 
     DatasetsByDOIResponse:
       type: object

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionsTable.scala
@@ -146,17 +146,107 @@ object PublicDatasetVersionsMapper
       .result
       .headOption
       .flatMap {
-        case Some((d, v))
-            if v.status in Seq(
-              PublishStatus.PublishSucceeded,
-              PublishStatus.EmbargoSucceeded
-            ) =>
+        case Some((d, v)) if v.status in successfulStates =>
           DBIO.successful((d, v))
         case Some((d, v)) if v.status == PublishStatus.Unpublished =>
           DBIO.failed(DatasetUnpublishedException(d, v))
         case _ =>
           DBIO.failed(NoDatasetForDoiException(doi))
       }
+
+  case class DatasetDetails(
+    dataset: PublicDataset,
+    version: PublicDatasetVersion,
+    contributors: IndexedSeq[PublicContributor],
+    sponsorship: Option[Sponsorship],
+    revision: Option[Revision],
+    collections: IndexedSeq[PublicCollection],
+    externalPublications: IndexedSeq[PublicExternalPublication],
+    release: Option[PublicDatasetRelease]
+  )
+
+  case class GetDatasetsByDoiResult(
+    published: Map[String, DatasetDetails] = Map.empty,
+    unpublished: Map[String, (PublicDataset, PublicDatasetVersion)] = Map.empty
+  )
+
+  def getDatasetsByDoi(
+    dois: List[String]
+  )(implicit
+    executionContext: ExecutionContext
+  ): DBIOAction[GetDatasetsByDoiResult, NoStream, Effect.Read] = {
+    if (dois.isEmpty) {
+      return DBIO.successful(GetDatasetsByDoiResult())
+    }
+
+    val datasetsWithSponsorshipsQuery = PublicDatasetsMapper
+      .join(this.filter(_.doi inSetBind dois))
+      .on(_.id === _.datasetId)
+      .joinLeft(SponsorshipsMapper)
+      .on(_._1.id === _.datasetId)
+
+    for {
+      datasetsWithSponsorships <- datasetsWithSponsorshipsQuery.result
+
+      (publishedWithSponsorships, unpublished) = datasetsWithSponsorships
+        .partition(_._1._2.status in successfulStates)
+
+      contributorsMap <- PublicContributorsMapper.getDatasetContributors(
+        publishedWithSponsorships.map {
+          case ((dataset, version), _) => (dataset, version)
+        }
+      )
+      collectionsMap <- PublicCollectionsMapper.getDatasetCollections(
+        publishedWithSponsorships.map {
+          case ((dataset, version), _) => (dataset, version)
+        }
+      )
+      externalPublicationsMap <- PublicExternalPublicationsMapper
+        .getExternalPublications(publishedWithSponsorships.map {
+          case ((dataset, version), _) => (dataset, version)
+        })
+
+      revisionsMap <- RevisionsMapper.getLatestRevisions(
+        publishedWithSponsorships.map {
+          case ((_, version), _) => version
+        }
+      )
+
+      releasesMap <- PublicDatasetReleaseMapper.getFor(
+        publishedWithSponsorships.map {
+          case ((dataset, version), _) => (dataset, version)
+        }
+      )
+
+    } yield {
+      val publishedByDoi = publishedWithSponsorships.view
+        .map(
+          tuple =>
+            tuple._1._2.doi -> DatasetDetails(
+              dataset = tuple._1._1,
+              version = tuple._1._2,
+              contributors =
+                contributorsMap.getOrElse(tuple._1, Nil).toIndexedSeq,
+              sponsorship = tuple._2,
+              revision = revisionsMap.get(tuple._1._2).flatten,
+              collections = collectionsMap.getOrElse(tuple._1, Nil).toIndexedSeq,
+              externalPublications =
+                externalPublicationsMap.getOrElse(tuple._1, Nil).toIndexedSeq,
+              release = releasesMap.get(tuple._1)
+            )
+        )
+        .toMap
+      val unpublishedByDoi =
+        unpublished.view
+          .map(tuple => tuple._1._2.doi -> (tuple._1._1, tuple._1._2))
+          .toMap
+      GetDatasetsByDoiResult(
+        published = publishedByDoi,
+        unpublished = unpublishedByDoi
+      )
+    }
+
+  }
 
   def getVersionCounts(
     status: PublishStatus = PublishSucceeded

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
@@ -44,7 +44,6 @@ import com.pennsieve.discover.server.definitions
 import com.pennsieve.discover.server.definitions.{
   AssetTreeNodeDto,
   AssetTreePage,
-  DatasetsByDoiRequest,
   DatasetsByDoiResponse,
   DownloadRequest,
   DownloadResponse,
@@ -343,12 +342,10 @@ class DatasetHandler(
   override def getDatasetsByDoi(
     respond: GuardrailResource.GetDatasetsByDoiResponse.type
   )(
-    body: DatasetsByDoiRequest
+    doi: Iterable[String]
   ): Future[GuardrailResource.GetDatasetsByDoiResponse] = {
     val query: DBIOAction[DatasetsByDoiResponse, NoStream, Effect.Read] = for {
-      datasetDetails <- PublicDatasetVersionsMapper.getDatasetsByDoi(
-        body.dois.toList
-      )
+      datasetDetails <- PublicDatasetVersionsMapper.getDatasetsByDoi(doi.toList)
     } yield datasetsByDoiResponse(datasetDetails)
     ports.db
       .run(query.transactionally)

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
@@ -40,6 +40,7 @@ import com.pennsieve.discover.server.definitions
 import com.pennsieve.discover.server.definitions.{
   AssetTreeNodeDto,
   AssetTreePage,
+  DatasetsByDoiRequest,
   DownloadRequest,
   DownloadResponse,
   DownloadResponseHeader,
@@ -306,6 +307,12 @@ class DatasetHandler(
           )
       }
   }
+
+  override def getDatasetsByDoi(
+    respond: GuardrailResource.GetDatasetsByDoiResponse.type
+  )(
+    body: DatasetsByDoiRequest
+  ): Future[GuardrailResource.GetDatasetsByDoiResponse] = ???
 
   override def requestPreview(
     respond: GuardrailResource.RequestPreviewResponse.type
@@ -1209,6 +1216,7 @@ class DatasetHandler(
        |
        |$agreement
        |""".stripMargin.trim
+
 }
 
 object DatasetHandler {

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
@@ -344,6 +344,11 @@ class DatasetHandler(
   )(
     doi: Iterable[String]
   ): Future[GuardrailResource.GetDatasetsByDoiResponse] = {
+    if (doi.isEmpty) {
+      return Future.successful(
+        GuardrailResource.GetDatasetsByDoiResponse.BadRequest("missing DOIs")
+      )
+    }
     val query: DBIOAction[DatasetsByDoiResponse, NoStream, Effect.Read] = for {
       datasetDetails <- PublicDatasetVersionsMapper.getDatasetsByDoi(doi.toList)
     } yield datasetsByDoiResponse(datasetDetails)

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -12,7 +12,8 @@ import com.pennsieve.models.{
   FileManifest,
   FileType,
   License,
-  PublishStatus
+  PublishStatus,
+  RelationshipType
 }
 import com.pennsieve.test.AwaitableImplicits
 import com.spotify.docker.client.DefaultDockerClient
@@ -442,6 +443,44 @@ object TestUtilities extends AwaitableImplicits {
             s3VersionId = s3Version
           )
         )
+      )
+      .awaitFinite()
+
+  def createSponsorship(
+    db: Database
+  )(
+    sourceOrganizationId: Int,
+    sourceDatasetId: Int,
+    title: Option[String] = Some(randomString()),
+    imageUrl: Option[String] = Some(randomString()),
+    markup: Option[String] = Some(randomString())
+  )(implicit
+    executionContext: ExecutionContext
+  ): Sponsorship =
+    db.run(
+        SponsorshipsMapper.createOrUpdate(
+          sourceOrganizationId,
+          sourceDatasetId,
+          title,
+          imageUrl,
+          markup
+        )
+      )
+      .awaitFinite()
+
+  def createExternalPublication(
+    db: Database
+  )(
+    datasetId: Int,
+    version: Int,
+    relationshipType: RelationshipType,
+    doi: String = randomString()
+  )(implicit
+    executionContext: ExecutionContext
+  ): PublicExternalPublication =
+    db.run(
+        PublicExternalPublicationsMapper
+          .create(doi, relationshipType, datasetId, version)
       )
       .awaitFinite()
 

--- a/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetVersionsMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetVersionsMapperSpec.scala
@@ -22,11 +22,13 @@ import com.pennsieve.discover.{
 }
 import com.pennsieve.models.PublishStatus
 import com.pennsieve.models.PublishStatus.{
+  EmbargoSucceeded,
   PublishFailed,
   PublishInProgress,
   PublishSucceeded,
   Unpublished
 }
+import com.pennsieve.models.RelationshipType.{ Documents, References, Requires }
 import com.pennsieve.test.AwaitableImplicits
 import org.postgresql.util.PSQLException
 import org.scalatest.matchers.should.Matchers
@@ -734,5 +736,212 @@ class PublicDatasetVersionsMapperSpec
         ReleaseFailed
       )
     } yield version.copy(status = status).underEmbargo shouldBe true
+  }
+
+  "retrieve dataset versions for given DOIs" in {
+    val ds1 =
+      TestUtilities.createDataset(ports.db)(sourceDatasetId = 1, name = "A")
+    val ds2 =
+      TestUtilities.createDataset(ports.db)(sourceDatasetId = 2, name = "B")
+    val ds3 =
+      TestUtilities.createDataset(ports.db)(sourceDatasetId = 3, name = "C")
+    val ds4 =
+      TestUtilities.createDataset(ports.db)(sourceDatasetId = 4, name = "D")
+    val ds1_v1 = TestUtilities.createNewDatasetVersion(ports.db)(
+      id = ds1.id,
+      status = PublishSucceeded
+    )
+    val ds2_v1_failed = TestUtilities.createNewDatasetVersion(ports.db)(
+      id = ds2.id,
+      status = PublishFailed,
+      size = 100L
+    )
+    val ds3_v1_embargoed = TestUtilities.createNewDatasetVersion(ports.db)(
+      id = ds3.id,
+      status = EmbargoSucceeded,
+      size = 90L
+    )
+    val ds4_v1 = TestUtilities.createNewDatasetVersion(ports.db)(
+      id = ds4.id,
+      status = PublishSucceeded,
+      size = 80L
+    )
+    val ds1_v2 = TestUtilities.createNewDatasetVersion(ports.db)(
+      id = ds1.id,
+      status = PublishSucceeded,
+      size = 70L
+    )
+
+    val ds1_v1_contrib = TestUtilities.createContributor(ports.db)(
+      firstName = "Henry",
+      lastName = "Winkler",
+      orcid = None,
+      datasetId = ds1.id,
+      organizationId = 1,
+      version = ds1_v1.version,
+      sourceContributorId = 1,
+      sourceUserId = Some(1)
+    )
+
+    TestUtilities.createContributor(ports.db)(
+      firstName = "Tom",
+      lastName = "Hanks",
+      orcid = None,
+      datasetId = ds2.id,
+      organizationId = 1,
+      version = ds2_v1_failed.version,
+      sourceContributorId = 2,
+      sourceUserId = Some(2)
+    )
+    val ds3_v1_embargoed_contrib = TestUtilities.createContributor(ports.db)(
+      firstName = "Tony",
+      lastName = "Parker",
+      orcid = None,
+      datasetId = ds3.id,
+      organizationId = 1,
+      version = ds3_v1_embargoed.version,
+      sourceContributorId = 3,
+      sourceUserId = Some(3)
+    )
+    val ds4_v1_contrib = TestUtilities.createContributor(ports.db)(
+      firstName = "Sally",
+      lastName = "Fields",
+      orcid = None,
+      datasetId = ds4.id,
+      organizationId = 1,
+      version = ds4_v1.version,
+      sourceContributorId = 4,
+      sourceUserId = Some(4)
+    )
+    val ds1_v2_contrib = TestUtilities.createContributor(ports.db)(
+      firstName = "Henry",
+      lastName = "Winkler",
+      orcid = None,
+      datasetId = ds1.id,
+      organizationId = 1,
+      version = ds1_v2.version,
+      sourceContributorId = 1,
+      sourceUserId = Some(1)
+    )
+
+    val ds1_sponsorship = TestUtilities.createSponsorship(ports.db)(
+      sourceOrganizationId = ds1.sourceOrganizationId,
+      sourceDatasetId = ds1.sourceDatasetId
+    )
+
+    val ds4_v1_revision = TestUtilities.createRevision(ports.db)(ds4_v1)
+
+    val ds1_v2_collection = TestUtilities.createCollection(ports.db)(
+      datasetId = ds1_v2.datasetId,
+      version = ds1_v2.version,
+      sourceCollectionId = 1
+    )
+
+    val ds4_v1_release = TestUtilities.createDatasetRelease(ports.db)(
+      ds4_v1.datasetId,
+      ds4_v1.version,
+      "GitHub",
+      "v1.0.0",
+      "https://github.com/Pennsieve/test-repo"
+    )
+
+    val ds1_v1_externalPub = TestUtilities.createExternalPublication(ports.db)(
+      ds1_v1.datasetId,
+      ds1_v1.version,
+      References
+    )
+
+    val ds4_v1_externalPub1 = TestUtilities.createExternalPublication(ports.db)(
+      ds4_v1.datasetId,
+      ds4_v1.version,
+      Requires
+    )
+
+    val ds4_v1_externalPub2 = TestUtilities.createExternalPublication(ports.db)(
+      ds4_v1.datasetId,
+      ds4_v1.version,
+      Documents
+    )
+
+    val result = ports.db
+      .run(
+        PublicDatasetVersionsMapper.getDatasetsByDoi(
+          dois = List(
+            ds1_v1.doi,
+            ds1_v2.doi,
+            ds2_v1_failed.doi,
+            ds3_v1_embargoed.doi,
+            ds4_v1.doi
+          )
+        )
+      )
+      .await
+
+    // Check published
+    result.published.size shouldBe 4
+
+    result.published should contain key ds1_v1.doi
+    result.published(ds1_v1.doi) shouldBe PublicDatasetVersionsMapper
+      .DatasetDetails(
+        dataset = ds1,
+        version = ds1_v1,
+        contributors = IndexedSeq(ds1_v1_contrib),
+        sponsorship = Some(ds1_sponsorship),
+        revision = None,
+        collections = IndexedSeq.empty,
+        externalPublications = IndexedSeq(ds1_v1_externalPub),
+        release = None
+      )
+
+    result.published should contain key ds1_v2.doi
+    result.published(ds1_v2.doi) shouldBe PublicDatasetVersionsMapper
+      .DatasetDetails(
+        dataset = ds1,
+        version = ds1_v2,
+        contributors = IndexedSeq(ds1_v2_contrib),
+        sponsorship = Some(ds1_sponsorship),
+        revision = None,
+        collections = IndexedSeq(ds1_v2_collection),
+        externalPublications = IndexedSeq.empty,
+        release = None
+      )
+
+    result.published should contain key ds3_v1_embargoed.doi
+    result.published(ds3_v1_embargoed.doi) shouldBe PublicDatasetVersionsMapper
+      .DatasetDetails(
+        dataset = ds3,
+        version = ds3_v1_embargoed,
+        contributors = IndexedSeq(ds3_v1_embargoed_contrib),
+        sponsorship = None,
+        revision = None,
+        collections = IndexedSeq.empty,
+        externalPublications = IndexedSeq.empty,
+        release = None
+      )
+
+    // Breaking this one up because the external pubs are not returned in a deterministic order
+    result.published should contain key ds4_v1.doi
+    result.published(ds4_v1.doi).dataset shouldBe ds4
+    result.published(ds4_v1.doi).version shouldBe ds4_v1
+    result.published(ds4_v1.doi).contributors shouldBe IndexedSeq(
+      ds4_v1_contrib
+    )
+    result.published(ds4_v1.doi).sponsorship shouldBe empty
+    result.published(ds4_v1.doi).revision shouldBe Some(ds4_v1_revision)
+    result.published(ds4_v1.doi).collections shouldBe empty
+    result
+      .published(ds4_v1.doi)
+      .externalPublications should contain theSameElementsAs IndexedSeq(
+      ds4_v1_externalPub1,
+      ds4_v1_externalPub2
+    )
+    result.published(ds4_v1.doi).release shouldBe Some(ds4_v1_release)
+
+    // Check Unpublished
+    result.unpublished.size shouldBe 1
+
+    result.unpublished should contain key ds2_v1_failed.doi
+    result.unpublished(ds2_v1_failed.doi) shouldBe (ds2, ds2_v1_failed)
+
   }
 }

--- a/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetVersionsMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetVersionsMapperSpec.scala
@@ -944,4 +944,14 @@ class PublicDatasetVersionsMapperSpec
     result.unpublished(ds2_v1_failed.doi) shouldBe (ds2, ds2_v1_failed)
 
   }
+
+  "return empty response when given an empty list of DOIs" in {
+    val result = ports.db
+      .run(PublicDatasetVersionsMapper.getDatasetsByDoi(dois = List.empty))
+      .await
+
+    result.published shouldBe empty
+    result.unpublished shouldBe empty
+
+  }
 }


### PR DESCRIPTION
Adds a new endpoint to retrieve Dataset details for a given list of DOIs. Requests will look like

`GET /datasets/doi?doi=<doi1>&doi=<doi2>&...`

The response is an object with two properties, `published` and `unpublished`. 

The value of `published` is a map from DOI to PublicDatasetDTO, the same object returned by `GET /datasets/{id}` for a published dataset.
The value of `unpublished` is a map from DOI to TombstoneDTO, the same object returned by `GET /datasets/{id}` when a dataset has been unpublished.

This is in support of the new collections-service which needed a way to get information for a batch of DOIs instead of one at a time.