### PR TITLE
Publish DOI Collections

### DIFF
--- a/openapi/discover-service-internal.yml
+++ b/openapi/discover-service-internal.yml
@@ -584,7 +584,7 @@ paths:
       summary: publish a collection to Discover
       security:
         - Bearer: [ ]
-      operationId: publishCollection
+      operationId: publishDOICollection
       x-scala-package: collection
       parameters:
         - name: collectionId
@@ -598,7 +598,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PublishCollectionRequest"
+              $ref: "#/components/schemas/PublishDOICollectionRequest"
         description: collection metadata
         required: true
       responses:
@@ -607,7 +607,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PublishCollectionResponse"
+                $ref: "#/components/schemas/PublishDOICollectionResponse"
         "400":
           description: Bad Request
           content:
@@ -997,7 +997,7 @@ components:
         readmeKey:
           type: string
 
-    PublishCollectionRequest:
+    PublishDOICollectionRequest:
       type: object
       required:
         - name
@@ -1056,7 +1056,7 @@ components:
         bucketConfig:
           $ref: "#/components/schemas/BucketConfig"
 
-    PublishCollectionResponse:
+    PublishDOICollectionResponse:
       type: object
       required:
         - name

--- a/openapi/discover-service-internal.yml
+++ b/openapi/discover-service-internal.yml
@@ -1180,6 +1180,7 @@ components:
       properties:
         status:
           type: string
+          x-scala-type: com.pennsieve.models.PublishStatus
 
     DatasetPublishStatus:
       type: object

--- a/openapi/discover-service-internal.yml
+++ b/openapi/discover-service-internal.yml
@@ -1002,8 +1002,9 @@ components:
       required:
         - name
         - description
+        - banners
+        - dois
         - ownerId
-        - doiCount
         - license
         - contributors
         - tags
@@ -1017,13 +1018,21 @@ components:
           type: string
         description:
           type: string
+        banners:
+          description: at most 4 banner URLs
+          maxItems: 4
+          type: array
+          items:
+            type: string
+        dois:
+          description: the DOIs in the collection
+          minItems: 1
+          type: array
+          items:
+            type: string
         ownerId:
           type: integer
           format: int32
-        doiCount:
-          description: number of DOIs in the collection
-          type: integer
-          format: int64
         license:
           type: string
           x-scala-type: com.pennsieve.models.License
@@ -1031,10 +1040,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/InternalContributor"
-        collections:
-          type: array
-          items:
-            $ref: "#/components/schemas/InternalCollection"
         externalPublications:
           type: array
           items:

--- a/openapi/discover-service-internal.yml
+++ b/openapi/discover-service-internal.yml
@@ -12,7 +12,7 @@ servers:
 paths:
   "/health":
     get:
-      security: []
+      security: [ ]
       summary: healthcheck
       operationId: healthcheck
       x-scala-package: healthcheck
@@ -31,7 +31,7 @@ paths:
     get:
       summary: get the publishing status of all organization datasets
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: getStatuses
       x-scala-package: publish
       parameters:
@@ -70,7 +70,7 @@ paths:
     get:
       summary: get the publishing status of a dataset
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: getStatus
       x-scala-package: publish
       parameters:
@@ -114,7 +114,7 @@ paths:
     post:
       summary: publish a dataset to Discover
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: publish
       x-scala-package: publish
       parameters:
@@ -186,7 +186,7 @@ paths:
     post:
       summary: revise the metadata (name, description, etc) for a published dataset
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: revise
       x-scala-package: publish
       parameters:
@@ -243,7 +243,7 @@ paths:
     post:
       summary: release an embargoed dataset to Discover
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: release
       x-scala-package: publish
       parameters:
@@ -296,7 +296,7 @@ paths:
     post:
       summary: unpublish a dataset
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: unpublish
       x-scala-package: publish
       parameters:
@@ -356,7 +356,7 @@ paths:
       summary: creates a sponsored dataset, or updates the sponsorship info if it
         already exists
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: sponsorDataset
       x-scala-package: publish
       parameters:
@@ -417,7 +417,7 @@ paths:
     delete:
       summary: removes a sponsorship from a dataset
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: removeDatasetSponsor
       x-scala-package: publish
       parameters:
@@ -469,7 +469,7 @@ paths:
     post:
       summary: publish a release to Discover
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: publishRelease
       x-scala-package: release
       parameters:
@@ -526,7 +526,7 @@ paths:
     post:
       summary: finalize the publishing of a release to Discover
       security:
-        - Bearer: []
+        - Bearer: [ ]
       operationId: finalizeRelease
       x-scala-package: release
       parameters:
@@ -579,30 +579,80 @@ paths:
               schema:
                 type: string
 
+  "/collection/{collectionId}/publish":
+    post:
+      summary: publish a collection to Discover
+      security:
+        - Bearer: [ ]
+      operationId: publishCollection
+      x-scala-package: collection
+      parameters:
+        - name: collectionId
+          in: path
+          description: collection id
+          required: true
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PublishCollectionRequest"
+        description: collection metadata
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublishCollectionResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                type: string
+
   "/metrics/dataset/athena/download/sync":
     get:
-      security: []
+      security: [ ]
       summary: sync
       operationId: syncAthenaDownloads
       x-scala-package: sync
       description: sync the Datasets Downloads table with the Downloads recorded in Athena
       parameters:
-      - name: startDate
-        in: query
-        description: Date for the beginning of download sync
-        required: true
-        schema:
-          type: string
-          format: date
-          nullable: true
-      - name: endDate
-        in: query
-        description: Date for the end of download sync
-        required: true
-        schema:
-          type: string
-          format: date
-          nullable: true
+        - name: startDate
+          in: query
+          description: Date for the beginning of download sync
+          required: true
+          schema:
+            type: string
+            format: date
+            nullable: true
+        - name: endDate
+          in: query
+          description: Date for the end of download sync
+          required: true
+          schema:
+            type: string
+            format: date
+            nullable: true
       responses:
         "200":
           description: Success
@@ -947,6 +997,98 @@ components:
         readmeKey:
           type: string
 
+    PublishCollectionRequest:
+      type: object
+      required:
+        - name
+        - description
+        - ownerId
+        - doiCount
+        - license
+        - contributors
+        - tags
+        - ownerNodeId
+        - ownerFirstName
+        - ownerLastName
+        - ownerOrcid
+        - collectionNodeId
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        ownerId:
+          type: integer
+          format: int32
+        doiCount:
+          description: number of DOIs in the collection
+          type: integer
+          format: int64
+        license:
+          type: string
+          x-scala-type: com.pennsieve.models.License
+        contributors:
+          type: array
+          items:
+            $ref: "#/components/schemas/InternalContributor"
+        collections:
+          type: array
+          items:
+            $ref: "#/components/schemas/InternalCollection"
+        externalPublications:
+          type: array
+          items:
+            $ref: "#/components/schemas/InternalExternalPublication"
+        tags:
+          type: array
+          items:
+            type: string
+        ownerNodeId:
+          type: string
+        ownerFirstName:
+          type: string
+        ownerLastName:
+          type: string
+        ownerOrcid:
+          type: string
+        collectionNodeId:
+          type: string
+        bucketConfig:
+          $ref: "#/components/schemas/BucketConfig"
+
+    PublishCollectionResponse:
+      type: object
+      required:
+        - name
+        - sourceCollectionId
+        - publishedDatasetId
+        - publishedVersion
+        - status
+        - publicId
+      properties:
+        name:
+          type: string
+        sourceCollectionId:
+          type: integer
+          format: int32
+        publishedDatasetId:
+          type: integer
+          format: int32
+        publishedVersion:
+          type: integer
+          format: int32
+        status:
+          type: string
+          x-scala-type: com.pennsieve.models.PublishStatus
+        lastPublishedDate:
+          type: string
+          format: date-time
+        sponsorship:
+          $ref: "#/components/schemas/SponsorshipRequest"
+        publicId:
+          type: string
+
+
     DatasetPublishStatus:
       type: object
       required:
@@ -986,8 +1128,8 @@ components:
     InternalCollection:
       type: object
       required:
-      - id
-      - name
+        - id
+        - name
       properties:
         id:
           type: integer
@@ -998,7 +1140,7 @@ components:
     InternalExternalPublication:
       type: object
       required:
-      - doi
+        - doi
       properties:
         doi:
           type: string

--- a/openapi/discover-service-internal.yml
+++ b/openapi/discover-service-internal.yml
@@ -629,6 +629,56 @@ paths:
               schema:
                 type: string
 
+  "/collection/{collectionId}/finalize":
+    post:
+      summary: finalize the publishing of a collection to Discover
+      security:
+        - Bearer: [ ]
+      operationId: finalizeDOICollection
+      x-scala-package: collection
+      parameters:
+        - name: collectionId
+          in: path
+          description: collection id
+          required: true
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FinalizeDOICollectionRequest"
+        description: collection publication data
+        required: true
+      responses:
+        "200":
+          description: Completed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FinalizeDOICollectionResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: Unauthorized
+        "403":
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                type: string
+
   "/metrics/dataset/athena/download/sync":
     get:
       security: [ ]
@@ -1093,6 +1143,43 @@ components:
         publicId:
           type: string
 
+    FinalizeDOICollectionRequest:
+      type: object
+      required:
+        - publishedDatasetId
+        - publishedVersion
+        - publishSuccess
+        - fileCount
+        - totalSize
+        - manifestKey
+        - manifestVersionId
+      properties:
+        publishedDatasetId:
+          type: integer
+          format: int32
+        publishedVersion:
+          type: integer
+          format: int32
+        publishSuccess:
+          type: boolean
+        fileCount:
+          type: integer
+          format: int64
+        totalSize:
+          type: integer
+          format: int64
+        manifestKey:
+          type: string
+        manifestVersionId:
+          type: string
+
+    FinalizeDOICollectionResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
 
     DatasetPublishStatus:
       type: object

--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -1371,6 +1371,8 @@ components:
           description: "the dataset type (research, release, collection)"
         release:
           $ref: "#/components/schemas/ReleaseInfo"
+        doiCollection:
+          $ref: "#/components/schemas/DOICollectionInfo"
 
     SponsorshipDTO:
       type: object
@@ -1661,6 +1663,18 @@ components:
         type:
           type: string
           description: either file or folder
+
+    DOICollectionInfo:
+      type: object
+      required:
+        - banners
+      properties:
+        banners:
+          description: at most 4 banner URLs
+          maxItems: 4
+          type: array
+          items:
+            type: string
 
     GenericResponsePage:
       description: >

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -197,3 +197,7 @@ runtime-settings = {
     delete-release-intermediate-file = "false"
     delete-release-intermediate-file = ${?DELETE_RELEASE_INTERMEDIATE_FILES}
 }
+
+doi-collections = {
+    pennsieve-doi-prefix = ${PENNSIEVE_DOI_PREFIX}
+}

--- a/server/src/main/resources/db/migration/V20250523132340__doi_collections_tables.sql
+++ b/server/src/main/resources/db/migration/V20250523132340__doi_collections_tables.sql
@@ -1,6 +1,6 @@
 /*
 ** Public Dataset DOI Collections
-**   This table holds the details of a DOI Collection.
+**   This table holds the DOI Collection specific details of a DOI Collection.
 ** Postgres does not enforce ARRAY[4] size. Just for documentation.
 */
 CREATE TABLE public_dataset_doi_collections

--- a/server/src/main/resources/db/migration/V20250523132340__doi_collections_tables.sql
+++ b/server/src/main/resources/db/migration/V20250523132340__doi_collections_tables.sql
@@ -1,0 +1,51 @@
+/*
+** Public Dataset DOI Collections
+**   This table holds the details of a DOI Collection.
+** Postgres does not enforce ARRAY[4] size. Just for documentation.
+*/
+CREATE TABLE public_dataset_doi_collections
+(
+    id              SERIAL PRIMARY KEY,
+    dataset_id      INT           NOT NULL,
+    dataset_version INT           NOT NULL,
+    banners         TEXT ARRAY[4] NOT NULL,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (dataset_id, dataset_version),
+    CONSTRAINT public_dataset_doi_collections_fk
+        FOREIGN KEY (dataset_id, dataset_version)
+            REFERENCES public_dataset_versions (dataset_id, version)
+            ON DELETE CASCADE
+);
+
+CREATE TRIGGER public_dataset_doi_collections_updated_at
+    BEFORE UPDATE
+    ON public_dataset_doi_collections
+    FOR EACH ROW
+EXECUTE PROCEDURE update_updated_at_column();
+
+/*
+** Public Dataset DOI Collection DOIs
+**   This table holds the DOI listing of the collection.
+*/
+CREATE TABLE public_dataset_doi_collection_dois
+(
+    id              SERIAL PRIMARY KEY,
+    dataset_id      INT          NOT NULL,
+    dataset_version INT          NOT NULL,
+    doi             VARCHAR(255) NOT NULL,
+    position        INT          NOT NULL,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (dataset_id, dataset_version, doi),
+    CONSTRAINT public_dataset_doi_collection_dois_fk
+        FOREIGN KEY (dataset_id, dataset_version)
+            REFERENCES public_dataset_versions (dataset_id, version)
+            ON DELETE CASCADE
+);
+
+CREATE TRIGGER public_dataset_doi_collection_dois_updated_at
+    BEFORE UPDATE
+    ON public_dataset_doi_collection_dois
+    FOR EACH ROW
+EXECUTE PROCEDURE update_updated_at_column();

--- a/server/src/main/scala/com/pennsieve/discover/Config.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Config.scala
@@ -33,7 +33,8 @@ case class Config(
   download: DownloadConfiguration,
   externalPublishBuckets: Map[S3Bucket, Arn] = Map.empty,
   athena: AthenaConfig,
-  runtimeSettings: RuntimeSettings
+  runtimeSettings: RuntimeSettings,
+  doiCollections: DoiCollections
 )
 
 object Config {
@@ -129,3 +130,5 @@ case class AthenaConfig(
 )
 
 case class RuntimeSettings(deleteReleaseIntermediateFile: Boolean)
+
+case class DoiCollections(pennsieveDoiPrefix: String)

--- a/server/src/main/scala/com/pennsieve/discover/Errors.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Errors.scala
@@ -123,3 +123,9 @@ case class UnsupportedDownloadVersion() extends Throwable {
   override def getMessage: String =
     "Only the most recent published dataset version can be downloaded"
 }
+
+case class NoDoiCollectionVersionException(id: Int, version: Int)
+    extends Throwable {
+  override def getMessage: String =
+    s"No DOI collection could be found for id=$id version=$version"
+}

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisTable.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.db
+
+import com.pennsieve.discover.db.profile.api._
+import com.pennsieve.discover.models.PublicDatasetDoiCollectionDoi
+import slick.dbio.{ DBIOAction, Effect }
+
+import java.time.OffsetDateTime
+import scala.concurrent.ExecutionContext
+final class PublicDatasetDoiCollectionDoisTable(tag: Tag)
+    extends Table[PublicDatasetDoiCollectionDoi](
+      tag,
+      "public_dataset_doi_collection_dois"
+    ) {
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def datasetId = column[Int]("dataset_id")
+  def datasetVersion = column[Int]("dataset_version")
+  def doi = column[String]("doi")
+  def position = column[Int]("position")
+  def createdAt = column[OffsetDateTime]("created_at")
+  def updatedAt = column[OffsetDateTime]("updated_at")
+
+  def * =
+    (id, datasetId, datasetVersion, doi, position, createdAt, updatedAt)
+      .mapTo[PublicDatasetDoiCollectionDoi]
+}
+
+object PublicDatasetDoiCollectionDoisMapper
+    extends TableQuery(new PublicDatasetDoiCollectionDoisTable(_)) {
+
+  def addDOIs(
+    datasetId: Int,
+    datasetVersion: Int,
+    dois: List[String]
+  )(implicit
+    executionContext: ExecutionContext
+  ): DBIOAction[Option[Int], NoStream, Effect.Read with Effect.Write with Effect.Transactional with Effect] =
+    this ++= dois.zipWithIndex
+      .map(
+        z =>
+          PublicDatasetDoiCollectionDoi(
+            datasetId = datasetId,
+            datasetVersion = datasetVersion,
+            doi = z._1,
+            position = z._2
+          )
+      )
+
+  def getDOIs(
+    datasetId: Int,
+    datasetVersion: Int
+  )(implicit
+    executionContext: ExecutionContext
+  ): DBIOAction[List[String], NoStream, Effect.Read] =
+    this
+      .filter(_.datasetId === datasetId)
+      .filter(_.datasetVersion === datasetVersion)
+      .sortBy(_.position.asc)
+      .map(_.doi)
+      .result
+      .map(_.toList)
+}

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisTable.scala
@@ -8,6 +8,7 @@ import slick.dbio.{ DBIOAction, Effect }
 
 import java.time.OffsetDateTime
 import scala.concurrent.ExecutionContext
+
 final class PublicDatasetDoiCollectionDoisTable(tag: Tag)
     extends Table[PublicDatasetDoiCollectionDoi](
       tag,

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionsTable.scala
@@ -1,0 +1,62 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.db
+
+import com.pennsieve.discover.NoDoiCollectionVersionException
+import com.pennsieve.discover.db.profile.api._
+import com.pennsieve.discover.models.PublicDatasetDoiCollection
+import slick.dbio.{ DBIOAction, Effect }
+
+import java.time.{ OffsetDateTime, ZoneOffset }
+import scala.concurrent.ExecutionContext
+
+final class PublicDatasetDoiCollectionsTable(tag: Tag)
+    extends Table[PublicDatasetDoiCollection](
+      tag,
+      "public_dataset_doi_collections"
+    ) {
+  def id = column[Int]("id", O.PrimaryKey, O.AutoInc)
+  def datasetId = column[Int]("dataset_id")
+  def datasetVersion = column[Int]("dataset_version")
+  def banners = column[List[String]]("banners")
+  def createdAt = column[OffsetDateTime]("created_at")
+  def updatedAt = column[OffsetDateTime]("updated_at")
+
+  def * =
+    (id, datasetId, datasetVersion, banners, createdAt, updatedAt)
+      .mapTo[PublicDatasetDoiCollection]
+}
+
+object PublicDatasetDoiCollectionsMapper
+    extends TableQuery(new PublicDatasetDoiCollectionsTable(_)) {
+
+  def add(
+    doiCollection: PublicDatasetDoiCollection
+  )(implicit
+    executionContext: ExecutionContext
+  ): DBIOAction[
+    PublicDatasetDoiCollection,
+    NoStream,
+    Effect.Read with Effect.Write with Effect.Transactional with Effect
+  ] =
+    (this returning this) += doiCollection
+
+  def getVersion(
+    datasetId: Int,
+    datasetVersion: Int
+  )(implicit
+    executionContext: ExecutionContext
+  ): DBIOAction[PublicDatasetDoiCollection, NoStream, Effect.Read] =
+    this
+      .filter(_.datasetId === datasetId)
+      .filter(_.datasetVersion === datasetVersion)
+      .result
+      .headOption
+      .flatMap {
+        case None =>
+          DBIO.failed(
+            NoDoiCollectionVersionException(datasetId, datasetVersion)
+          )
+        case Some(dataset) => DBIO.successful(dataset)
+      }
+}

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
@@ -25,6 +25,7 @@ import com.pennsieve.discover.clients.{
   HttpError
 }
 import com.pennsieve.discover.db.PublicDatasetVersionsMapper.{
+  deleteVersion,
   DatasetDetails,
   GetDatasetsByDoiResult
 }
@@ -130,7 +131,8 @@ class DatasetHandler(
     dataset: PublicDataset,
     version: PublicDatasetVersion,
     preview: Option[DatasetPreview] = None,
-    release: Option[PublicDatasetRelease] = None
+    release: Option[PublicDatasetRelease] = None,
+    doiCollection: Option[PublicDatasetDoiCollection] = None
   ): DBIO[PublicDatasetDto] =
     for {
 
@@ -147,7 +149,8 @@ class DatasetHandler(
         collections.toSeq,
         externalPublications.toSeq,
         preview,
-        release = release
+        release = release,
+        doiCollection = doiCollection
       )
 
   private def datasetsByDoiResponse(
@@ -256,6 +259,10 @@ class DatasetHandler(
         }
 
       release <- PublicDatasetReleaseMapper.get(dataset.id, version.version)
+      doiCollection <- PublicDatasetDoiCollectionsMapper.get(
+        dataset.id,
+        version.version
+      )
 
       maybeDatasetPreview <- DBIO.from {
         claim
@@ -277,7 +284,13 @@ class DatasetHandler(
           .getOrElse(Future.successful(None))
       }
 
-      dto <- publicDatasetDTO(dataset, version, maybeDatasetPreview, release)
+      dto <- publicDatasetDTO(
+        dataset,
+        version,
+        maybeDatasetPreview,
+        release,
+        doiCollection
+      )
 
     } yield dto
 
@@ -318,7 +331,17 @@ class DatasetHandler(
 
       release <- PublicDatasetReleaseMapper.get(dataset.id, version.version)
 
-      dto <- publicDatasetDTO(dataset, version, release = release)
+      doiCollection <- PublicDatasetDoiCollectionsMapper.get(
+        dataset.id,
+        version.version
+      )
+
+      dto <- publicDatasetDTO(
+        dataset,
+        version,
+        release = release,
+        doiCollection = doiCollection
+      )
 
     } yield dto
 
@@ -524,7 +547,17 @@ class DatasetHandler(
 
       release <- PublicDatasetReleaseMapper.get(dataset.id, version.version)
 
-      dto <- publicDatasetDTO(dataset, version, release = release)
+      doiCollection <- PublicDatasetDoiCollectionsMapper.get(
+        dataset.id,
+        version.version
+      )
+
+      dto <- publicDatasetDTO(
+        dataset,
+        version,
+        release = release,
+        doiCollection = doiCollection
+      )
 
     } yield dto
 

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
@@ -165,7 +165,8 @@ class DatasetHandler(
             x.collections,
             x.externalPublications,
             datasetPreview = None,
-            release = x.release
+            release = x.release,
+            doiCollection = x.doiCollection
           )
       )
     val unpublished = queryResults.unpublished.view

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DoiCollectionHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DoiCollectionHandler.scala
@@ -33,13 +33,13 @@ import com.pennsieve.discover.server.collection.{
   CollectionHandler => GuardrailHandler,
   CollectionResource => GuardrailResource
 }
-import com.pennsieve.discover.server.definitions.PublishCollectionRequest
+import com.pennsieve.discover.server.definitions.PublishDoiCollectionRequest
 import com.pennsieve.discover.utils.{ getOrCreateDoi, BucketResolver }
 import com.pennsieve.models.PublishStatus
 import io.circe.DecodingFailure
 import slick.jdbc.TransactionIsolation
 import com.pennsieve.discover.db.profile.api._
-import com.pennsieve.discover.handlers.CollectionHandler.{
+import com.pennsieve.discover.handlers.DoiCollectionHandler.{
   collectionOrgId,
   collectionOrgName
 }
@@ -48,21 +48,22 @@ import com.pennsieve.models.DatasetType.Collection
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 
-class CollectionHandler(
+class DoiCollectionHandler(
   ports: Ports,
   claim: Jwt.Claim
 )(implicit
   system: ActorSystem,
   executionContext: ExecutionContext
 ) extends GuardrailHandler {
-  type PublishCollectionResponse = GuardrailResource.PublishCollectionResponse
+  type PublishDoiCollectionResponse =
+    GuardrailResource.PublishDoiCollectionResponse
 
-  override def publishCollection(
-    respond: GuardrailResource.PublishCollectionResponse.type
+  override def publishDoiCollection(
+    respond: GuardrailResource.PublishDoiCollectionResponse.type
   )(
     collectionId: Int,
-    body: PublishCollectionRequest
-  ): Future[PublishCollectionResponse] = {
+    body: PublishDoiCollectionRequest
+  ): Future[PublishDoiCollectionResponse] = {
     implicit val logContext: DiscoverLogContext = DiscoverLogContext(
       datasetId = Some(collectionId),
       userId = Some(body.ownerId)
@@ -76,7 +77,7 @@ class CollectionHandler(
         Some(PublishingWorkflow.Version5)
       )
 
-    withServiceOwnerAuthorization[PublishCollectionResponse](
+    withServiceOwnerAuthorization[PublishDoiCollectionResponse](
       claim,
       collectionOrgId,
       collectionId
@@ -121,7 +122,7 @@ class CollectionHandler(
             _ = ports.log.info(s"Public dataset version : $version")
 
             response = com.pennsieve.discover.server.definitions
-              .PublishCollectionResponse(
+              .PublishDoiCollectionResponse(
                 name = publicDataset.name,
                 sourceCollectionId = publicDataset.sourceDatasetId,
                 publishedDatasetId = version.datasetId,
@@ -168,7 +169,7 @@ class CollectionHandler(
   }
 }
 
-object CollectionHandler {
+object DoiCollectionHandler {
   val collectionOrgId = -20
   val collectionOrgName = "Fake Collection Organization"
   def routes(
@@ -179,7 +180,7 @@ object CollectionHandler {
   ): Route = {
     logRequestAndResponse(ports) {
       authenticateJwt(system.name)(ports.jwt) { claim =>
-        GuardrailResource.routes(new CollectionHandler(ports, claim))
+        GuardrailResource.routes(new DoiCollectionHandler(ports, claim))
       }
     }
   }

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DoiCollectionHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DoiCollectionHandler.scala
@@ -3,11 +3,10 @@
 package com.pennsieve.discover.handlers
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.server.{ FIXME, Route }
+import akka.http.scaladsl.server.Route
 import com.pennsieve.auth.middleware.AkkaDirective.authenticateJwt
 import com.pennsieve.auth.middleware.Jwt
 import com.pennsieve.discover.Authenticator.withServiceOwnerAuthorization
-import com.pennsieve.discover.db.PublicDatasetVersionsMapper.DatasetDetails
 import com.pennsieve.discover.db.{
   PublicDatasetDoiCollectionDoisMapper,
   PublicDatasetDoiCollectionsMapper,
@@ -32,14 +31,16 @@ import com.pennsieve.discover.{
   ForbiddenException,
   MissingParameterException,
   Ports,
-  PublishJobException,
   UnauthorizedException
 }
 import com.pennsieve.discover.server.collection.{
   CollectionHandler => GuardrailHandler,
   CollectionResource => GuardrailResource
 }
-import com.pennsieve.discover.server.definitions.PublishDoiCollectionRequest
+import com.pennsieve.discover.server.definitions.{
+  FinalizeDoiCollectionRequest,
+  PublishDoiCollectionRequest
+}
 import com.pennsieve.discover.utils.{ getOrCreateDoi, BucketResolver }
 import com.pennsieve.models.PublishStatus
 import io.circe.DecodingFailure
@@ -49,7 +50,7 @@ import com.pennsieve.discover.handlers.DoiCollectionHandler.{
   collectionOrgId,
   collectionOrgName
 }
-import com.pennsieve.models.DatasetType.{ Collection, Release }
+import com.pennsieve.models.DatasetType.Collection
 
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
@@ -63,6 +64,8 @@ class DoiCollectionHandler(
 ) extends GuardrailHandler {
   type PublishDoiCollectionResponse =
     GuardrailResource.PublishDoiCollectionResponse
+  type FinalizeDoiCollectionResponse =
+    GuardrailResource.FinalizeDoiCollectionResponse
   private val pennsieveDoiPrefix =
     ports.config.doiCollections.pennsieveDoiPrefix
 
@@ -256,6 +259,12 @@ class DoiCollectionHandler(
     } yield ()
   }
 
+  override def finalizeDoiCollection(
+    respond: GuardrailResource.FinalizeDoiCollectionResponse.type
+  )(
+    collectionId: Int,
+    body: FinalizeDoiCollectionRequest
+  ): Future[FinalizeDoiCollectionResponse] = ???
 }
 
 object DoiCollectionHandler {

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DoiCollectionHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DoiCollectionHandler.scala
@@ -209,6 +209,7 @@ class DoiCollectionHandler(
         case _ => Future.successful(())
       }
 
+      // For now, non-Pennsieve DOIs are not allowed. May be allowed in future.
       _ <- findNonPennsieveDois(dois) match {
         case Nil => Future.successful(())
         case nonPenn =>
@@ -219,6 +220,9 @@ class DoiCollectionHandler(
           )
       }
 
+      // Decided not to check on the published DOIs since in the future, if we
+      // allow non-Pennsieve DOIs it will be normal to have DOIs that do
+      // not appear in the published part of getDatasetsByDoi response.
       unpublishedDois <- findUnpublishedDois(dois)
       _ <- unpublishedDois match {
         case Nil => Future.successful(())

--- a/server/src/main/scala/com/pennsieve/discover/models/DatasetsPage.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/DatasetsPage.scala
@@ -30,7 +30,8 @@ object DatasetsPage {
                 revision,
                 collections,
                 externalPublications,
-                release
+                release,
+                doiCollection
                 ) =>
               PublicDatasetDTO
                 .apply(
@@ -42,7 +43,8 @@ object DatasetsPage {
                   collections,
                   externalPublications,
                   None,
-                  release
+                  release,
+                  doiCollection
                 )
           }.toVector
       )

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDTO.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDTO.scala
@@ -29,6 +29,13 @@ object PublicDatasetDTO {
       case None => None
     }
 
+  private def doiCollectionInfo(
+    doiCollection: Option[PublicDatasetDoiCollection]
+  ): Option[definitions.DoiCollectionInfo] =
+    doiCollection.map(
+      c => definitions.DoiCollectionInfo(banners = c.banners.toVector)
+    )
+
   def apply(
     dataset: PublicDataset,
     version: PublicDatasetVersion,
@@ -40,7 +47,8 @@ object PublicDatasetDTO {
       IndexedSeq[definitions.PublicExternalPublicationDto]
     ],
     datasetPreview: Option[DatasetPreview],
-    release: Option[PublicDatasetRelease]
+    release: Option[PublicDatasetRelease],
+    doiCollection: Option[PublicDatasetDoiCollection]
   )(implicit
     config: Config
   ): definitions.PublicDatasetDto =
@@ -121,6 +129,7 @@ object PublicDatasetDTO {
       )
       .withFieldComputed(_.sponsorship, _ => sponsorship)
       .withFieldComputed(_.release, _ => releaseInfo(release))
+      .withFieldComputed(_.doiCollection, _ => doiCollectionInfo(doiCollection))
       // TODO: pennsieveSchemaVersion can be non-optional once ElasticSearch has
       // been reindexed in production so that all datasets have a schema
       // version.
@@ -150,7 +159,8 @@ object PublicDatasetDTO {
     collections: Seq[PublicCollection],
     externalPublications: Seq[PublicExternalPublication],
     datasetPreview: Option[DatasetPreview],
-    release: Option[PublicDatasetRelease] = None
+    release: Option[PublicDatasetRelease] = None,
+    doiCollection: Option[PublicDatasetDoiCollection] = None
   )(implicit
     config: Config
   ): definitions.PublicDatasetDto = {
@@ -173,7 +183,8 @@ object PublicDatasetDTO {
           .toIndexedSeq
       ),
       datasetPreview = datasetPreview,
-      release
+      release,
+      doiCollection
     )
   }
 }

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollection.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollection.scala
@@ -16,7 +16,7 @@ case class PublicDatasetDoiCollection(
 object PublicDatasetDoiCollection {
 
   val collectionOrgId = -20
-  val collectionOrgName = "Fake Collection Organization"
+  val collectionOrgName = "DOI Collection ID Space"
   /*
    * This is required by slick when using a companion object on a case
    * class that defines a database table

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollection.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollection.scala
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+import java.time.{ OffsetDateTime, ZoneOffset }
+
+case class PublicDatasetDoiCollection(
+  id: Int = 0,
+  datasetId: Int,
+  datasetVersion: Int,
+  banners: List[String] = List.empty,
+  createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
+  updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
+)
+
+object PublicDatasetDoiCollection {
+
+  val collectionOrgId = -20
+  val collectionOrgName = "Fake Collection Organization"
+  /*
+   * This is required by slick when using a companion object on a case
+   * class that defines a database table
+   */
+  val tupled: (
+    (Int, Int, Int, List[String], OffsetDateTime, OffsetDateTime)
+  ) => PublicDatasetDoiCollection = (this.apply _).tupled
+}

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollectionDoi.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollectionDoi.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+import java.time.{ OffsetDateTime, ZoneOffset }
+
+case class PublicDatasetDoiCollectionDoi(
+  id: Int = 0,
+  datasetId: Int,
+  datasetVersion: Int,
+  doi: String,
+  position: Int,
+  createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
+  updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
+)
+
+object PublicDatasetDoiCollectionDoi {
+  /*
+   * This is required by slick when using a companion object on a case
+   * class that defines a database table
+   */
+  val tupled: (
+    (Int, Int, Int, String, Int, OffsetDateTime, OffsetDateTime)
+  ) => PublicDatasetDoiCollectionDoi = (this.apply _).tupled
+}

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -10,3 +10,7 @@ external-publish-buckets = [
         role-arn = "arn:aws:iam::999999999999:role/external-bucket-2-access-role"
     },
 ]
+
+doi-collections = {
+    pennsieve-doi-prefix = "10.00000"
+}

--- a/server/src/test/resources/config-with-external-buckets.conf
+++ b/server/src/test/resources/config-with-external-buckets.conf
@@ -169,3 +169,7 @@ runtime-settings = {
     delete-release-intermediate-file = "false"
     delete-release-intermediate-file = ${?DELETE_RELEASE_INTERMEDIATE_FILES}
 }
+
+doi-collections = {
+    pennsieve-doi-prefix = "10.00000"
+}

--- a/server/src/test/resources/config-without-external-buckets.conf
+++ b/server/src/test/resources/config-without-external-buckets.conf
@@ -158,3 +158,7 @@ runtime-settings = {
     delete-release-intermediate-file = "false"
     delete-release-intermediate-file = ${?DELETE_RELEASE_INTERMEDIATE_FILES}
 }
+
+doi-collections = {
+    pennsieve-doi-prefix = "10.00000"
+}

--- a/server/src/test/scala/com/pennsieve/discover/ConfigSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ConfigSpec.scala
@@ -37,5 +37,12 @@ class ConfigSpec extends AnyWordSpec with Matchers {
       config.externalPublishBuckets.isEmpty should be(true)
     }
 
+    "parse the doi-collections section correctly" in {
+      val config: Config =
+        Config.loadForTest("config-with-external-buckets.conf")
+
+      config.doiCollections.pennsieveDoiPrefix shouldBe "10.00000"
+    }
+
   }
 }

--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -116,7 +116,8 @@ trait ServiceSpecHarness
         rejoinBucketAccessTable =
           "rejoin_glue_catalog.dev_s3_access_logs_db.discover"
       ),
-      runtimeSettings = RuntimeSettings(deleteReleaseIntermediateFile = false)
+      runtimeSettings = RuntimeSettings(deleteReleaseIntermediateFile = false),
+      doiCollections = DoiCollections(pennsieveDoiPrefix = "10.00000")
     )
 
   def getPorts(config: Config): Ports = {

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -562,6 +562,67 @@ object TestUtilities extends AwaitableImplicits {
       .await
   }
 
+  def createDoiCollectionDataset(
+    db: Database
+  )(
+    name: String = "My Dataset",
+    sourceDatasetId: Int = 1,
+    ownerId: Int = 1,
+    ownerFirstName: String = "Fynn",
+    ownerLastName: String = "Blackwell",
+    ownerOrcid: String = "0000-0001-2345-6789",
+    license: License = License.`Apache 2.0`
+  )(implicit
+    executionContext: ExecutionContext
+  ): PublicDataset = {
+    db.run(
+        PublicDatasetsMapper.createOrUpdate(
+          name = name,
+          sourceOrganizationId = PublicDatasetDoiCollection.collectionOrgId,
+          sourceOrganizationName = PublicDatasetDoiCollection.collectionOrgName,
+          sourceDatasetId = sourceDatasetId,
+          ownerId = ownerId,
+          ownerFirstName = ownerFirstName,
+          ownerLastName = ownerLastName,
+          ownerOrcid = ownerOrcid,
+          license = license,
+          tags = List.empty,
+          datasetType = DatasetType.Collection
+        )
+      )
+      .await
+
+  }
+
+  def randomBannerUrls: List[String] =
+    List(
+      s"https://example.com/${randomString()}.png",
+      s"https://images.example.com/${randomString()}/${randomString()}.jpg",
+      s"https://example.com/${randomString()}.png",
+      s"https://images.example.com/${randomString()}/${randomString()}.jpg"
+    )
+
+  def createDatasetDoiCollection(
+    db: Database
+  )(
+    datasetId: Int,
+    datasetVersion: Int,
+    banners: List[String]
+  )(implicit
+    executionContext: ExecutionContext
+  ): PublicDatasetDoiCollection = {
+    db.run(
+        PublicDatasetDoiCollectionsMapper.add(
+          PublicDatasetDoiCollection(
+            datasetId = datasetId,
+            datasetVersion = datasetVersion,
+            banners = banners
+          )
+        )
+      )
+      .await
+  }
+
   /**
     * Our tests use a Whisk library, that in turn uses a Spotify library, to manage
     * docker containers created for tests. The Spotify part of this is no longer updated and breaks

--- a/server/src/test/scala/com/pennsieve/discover/handlers/CollectionHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/CollectionHandlerSpec.scala
@@ -1,0 +1,371 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.handlers
+
+import akka.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
+import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import com.pennsieve.test.EitherValue._
+import com.pennsieve.auth.middleware.Jwt
+import com.pennsieve.discover.Authenticator.{
+  generateServiceToken,
+  generateUserToken
+}
+import com.pennsieve.discover.{ ServiceSpecHarness, TestUtilities }
+import com.pennsieve.discover.client.collection.PublishCollectionResponse
+import com.pennsieve.discover.client.collection.CollectionClient
+import com.pennsieve.discover.client.{ collection, definitions }
+import com.pennsieve.discover.client.definitions.{
+  DatasetPublishStatus,
+  PublishCollectionRequest
+}
+import com.pennsieve.discover.clients.MockDoiClient
+import com.pennsieve.discover.db.{
+  PublicDatasetVersionsMapper,
+  PublicDatasetsMapper
+}
+import com.pennsieve.discover.models.{ PublishingWorkflow, S3Bucket, S3Key }
+import com.pennsieve.models.DatasetType.Collection
+import com.pennsieve.models.PublishStatus.{
+  PublishFailed,
+  PublishInProgress,
+  PublishSucceeded
+}
+import com.pennsieve.models.{ Degree, License, PublishStatus, RelationshipType }
+import org.scalatest.Inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CollectionHandlerSpec
+    extends AnyWordSpec
+    with Matchers
+    with Inside
+    with ScalatestRouteTest
+    with ServiceSpecHarness {
+  def createRoutes(): Route =
+    Route.seal(CollectionHandler.routes(ports))
+
+  def createClient(routes: Route): CollectionClient =
+    CollectionClient.httpClient(Route.toFunction(routes))
+
+  private val client = createClient(createRoutes())
+
+  val collectionName = "Dataset"
+  val collectionId = 34
+  val collectionNodeId = "abc123-xyz-456"
+  val ownerId = 1
+  val ownerNodeId = "N:user:abc123"
+  val ownerFirstName = "Data"
+  val ownerLastName = "Digger"
+  val ownerOrcid = "0000-0012-3456-7890"
+
+  private val requestBody: PublishCollectionRequest = PublishCollectionRequest(
+    name = collectionName,
+    description = "This is a test collection for publishing",
+    ownerId = ownerId,
+    doiCount = 5,
+    license = License.`Apache License 2.0`,
+    ownerNodeId = ownerNodeId,
+    ownerFirstName = ownerFirstName,
+    ownerLastName = ownerLastName,
+    ownerOrcid = ownerOrcid,
+    collectionNodeId = collectionNodeId
+  )
+
+  private val customBucketConfig =
+    definitions.BucketConfig("org-publish-bucket", "org-embargo-bucket")
+
+  private val customBucketRequestBody =
+    requestBody.copy(bucketConfig = Some(customBucketConfig))
+
+  val token: Jwt.Token =
+    generateServiceToken(
+      ports.jwt,
+      organizationId = CollectionHandler.collectionOrgId,
+      datasetId = collectionId
+    )
+
+  private val authToken = List(Authorization(OAuth2BearerToken(token.value)))
+
+  val userToken: Jwt.Token =
+    generateUserToken(
+      ports.jwt,
+      1,
+      CollectionHandler.collectionOrgId,
+      Some(collectionId)
+    )
+
+  private val userAuthToken = List(
+    Authorization(OAuth2BearerToken(userToken.value))
+  )
+
+  "POST /collection/{collectionId}/publish" should {
+    "fail without a JWT" in {
+
+      val response = client
+        .publishCollection(collectionId, requestBody)
+        .awaitFinite()
+        .value
+
+      response shouldBe PublishCollectionResponse.Unauthorized
+    }
+
+    "fail with a user JWT" in {
+      val response = client
+        .publishCollection(collectionId, requestBody, userAuthToken)
+        .awaitFinite()
+        .value
+
+      response shouldBe PublishCollectionResponse.Forbidden(
+        "Only allowed for service level requests"
+      )
+    }
+
+    "create a DB entry and link a DOI" in {
+
+      val response = client
+        .publishCollection(collectionId, requestBody, authToken)
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishCollectionResponse.Created]
+        .value
+
+      val publicDataset = ports.db
+        .run(
+          PublicDatasetsMapper
+            .getDatasetFromSourceIds(
+              CollectionHandler.collectionOrgId,
+              collectionId
+            )
+        )
+        .awaitFinite()
+
+      publicDataset.name shouldBe requestBody.name
+      publicDataset.sourceOrganizationId shouldBe CollectionHandler.collectionOrgId
+      publicDataset.sourceDatasetId shouldBe collectionId
+      publicDataset.ownerId shouldBe requestBody.ownerId
+      publicDataset.ownerFirstName shouldBe requestBody.ownerFirstName
+      publicDataset.ownerLastName shouldBe requestBody.ownerLastName
+      publicDataset.ownerOrcid shouldBe requestBody.ownerOrcid
+      publicDataset.datasetType shouldBe Collection
+
+      val publicVersion = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getLatestVersion(publicDataset.id)
+        )
+        .awaitFinite()
+        .get
+
+      val doiDto = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .getMockDoi(CollectionHandler.collectionOrgId, collectionId)
+        .get
+
+      publicVersion.version shouldBe 1
+      publicVersion.modelCount shouldBe empty
+      publicVersion.recordCount shouldBe 0
+      publicVersion.fileCount shouldBe 1
+      publicVersion.size shouldBe 0
+      publicVersion.description shouldBe requestBody.description
+      publicVersion.status shouldBe PublishStatus.PublishInProgress
+      publicVersion.s3Bucket shouldBe config.s3.publish50Bucket
+      publicVersion.s3Key shouldBe S3Key.Version(s"${publicDataset.id}/")
+      publicVersion.doi shouldBe doiDto.doi
+
+      response shouldBe com.pennsieve.discover.client.definitions
+        .PublishCollectionResponse(
+          name = collectionName,
+          sourceCollectionId = collectionId,
+          publishedDatasetId = publicDataset.id,
+          publishedVersion = publicVersion.version,
+          status = PublishInProgress,
+          lastPublishedDate = Some(publicVersion.createdAt),
+          sponsorship = None,
+          publicId = publicVersion.doi
+        )
+
+    }
+
+    "correctly use custom publish bucket" in {
+
+      client
+        .publishCollection(collectionId, customBucketRequestBody, authToken)
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishCollectionResponse.Created]
+        .value
+
+      val publicDataset = ports.db
+        .run(
+          PublicDatasetsMapper
+            .getDatasetFromSourceIds(
+              CollectionHandler.collectionOrgId,
+              collectionId
+            )
+        )
+        .awaitFinite()
+
+      val publicVersion = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getLatestVersion(publicDataset.id)
+        )
+        .awaitFinite()
+        .get
+
+      publicVersion.s3Bucket.value shouldBe customBucketConfig.publish
+
+    }
+
+    "return the publishing status of the dataset" in {
+
+      val publicDataset = TestUtilities.createDataset(ports.db)(
+        sourceOrganizationId = CollectionHandler.collectionOrgId,
+        sourceDatasetId = collectionId
+      )
+      val publicDataset1_V1 =
+        TestUtilities.createNewDatasetVersion(ports.db)(
+          id = publicDataset.id,
+          status = PublishSucceeded
+        )
+
+      val response = client
+        .publishCollection(collectionId, requestBody, authToken)
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishCollectionResponse.Created]
+        .value
+
+      val publicVersion = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getLatestVersion(publicDataset.id)
+        )
+        .awaitFinite()
+        .get
+
+      response shouldBe com.pennsieve.discover.client.definitions
+        .PublishCollectionResponse(
+          name = collectionName,
+          sourceCollectionId = collectionId,
+          publishedDatasetId = publicDataset.id,
+          publishedVersion = 2,
+          status = PublishInProgress,
+          lastPublishedDate = Some(publicVersion.createdAt),
+          sponsorship = None,
+          publicId = publicVersion.doi
+        )
+
+      val doiDto = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .getMockDoi(CollectionHandler.collectionOrgId, collectionId)
+        .get
+
+      publicVersion.version shouldBe 2
+      publicVersion.modelCount shouldBe empty
+      publicVersion.recordCount shouldBe 0
+      publicVersion.fileCount shouldBe 1
+      publicVersion.size shouldBe 0
+      publicVersion.status shouldBe PublishStatus.PublishInProgress
+      publicVersion.s3Bucket shouldBe config.s3.publish50Bucket
+      publicVersion.s3Key shouldBe S3Key.Version(s"${publicDataset.id}/")
+      publicVersion.doi shouldBe doiDto.doi
+
+    }
+
+    "delete a previously failed version before creating a new one" in {
+
+      val publicDataset = TestUtilities.createDataset(ports.db)(
+        sourceOrganizationId = CollectionHandler.collectionOrgId,
+        sourceDatasetId = collectionId,
+        datasetType = Collection
+      )
+      TestUtilities.createNewDatasetVersion(ports.db)(
+        id = publicDataset.id,
+        status = PublishFailed
+      )
+
+      val response = client
+        .publishCollection(collectionId, requestBody, authToken)
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishCollectionResponse.Created]
+        .value
+
+      val latestVersion = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getLatestVersion(publicDataset.id)
+        )
+        .awaitFinite()
+        .get
+
+      response shouldBe com.pennsieve.discover.client.definitions
+        .PublishCollectionResponse(
+          name = collectionName,
+          sourceCollectionId = collectionId,
+          publishedDatasetId = publicDataset.id,
+          publishedVersion = 1,
+          status = PublishInProgress,
+          lastPublishedDate = Some(latestVersion.createdAt),
+          sponsorship = None,
+          publicId = latestVersion.doi
+        )
+
+      val doiDto = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .getMockDoi(CollectionHandler.collectionOrgId, collectionId)
+        .get
+
+      latestVersion.version shouldBe 1
+      latestVersion.modelCount shouldBe empty
+      latestVersion.recordCount shouldBe 0
+      latestVersion.fileCount shouldBe 1
+      latestVersion.size shouldBe 0
+      latestVersion.status shouldBe PublishStatus.PublishInProgress
+      latestVersion.s3Bucket shouldBe config.s3.publish50Bucket
+      latestVersion.s3Key shouldBe S3Key.Version(s"${publicDataset.id}/")
+      latestVersion.doi shouldBe doiDto.doi
+
+    }
+
+    "not create a new DOI if draft DOI is only associated with a failed version" in {
+
+      val publicDataset = TestUtilities.createDataset(ports.db)(
+        sourceOrganizationId = CollectionHandler.collectionOrgId,
+        sourceDatasetId = collectionId,
+        datasetType = Collection
+      )
+      val draftDoi = ports.doiClient
+        .asInstanceOf[MockDoiClient]
+        .createMockDoi(CollectionHandler.collectionOrgId, collectionId)
+        .doi
+
+      TestUtilities.createNewDatasetVersion(ports.db)(
+        id = publicDataset.id,
+        status = PublishFailed,
+        doi = draftDoi
+      )
+
+      client
+        .publishCollection(collectionId, requestBody, authToken)
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishCollectionResponse.Created]
+        .value
+
+      val latestVersion = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getLatestVersion(publicDataset.id)
+        )
+        .awaitFinite()
+        .get
+
+      latestVersion.doi shouldBe draftDoi
+
+    }
+
+  }
+}

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -342,6 +342,7 @@ class DatasetHandlerSpec
             embargoAccess = "Requested"
           )
         ),
+        None,
         None
       )
 
@@ -364,6 +365,7 @@ class DatasetHandlerSpec
         None,
         Some(IndexedSeq(PublicCollectionDTO.apply(collection))),
         Some(IndexedSeq.empty),
+        None,
         None,
         None
       )
@@ -1121,6 +1123,7 @@ class DatasetHandlerSpec
             Some(IndexedSeq(PublicCollectionDTO(collection3))),
             Some(IndexedSeq.empty),
             None,
+            None,
             None
           )
         )
@@ -1137,6 +1140,7 @@ class DatasetHandlerSpec
             Some(IndexedSeq(PublicCollectionDTO(collection2))),
             Some(IndexedSeq.empty),
             None,
+            None,
             None
           )
         ),
@@ -1150,6 +1154,7 @@ class DatasetHandlerSpec
             None,
             Some(IndexedSeq(PublicCollectionDTO(collection1))),
             Some(IndexedSeq.empty),
+            None,
             None,
             None
           )
@@ -2659,6 +2664,7 @@ class DatasetHandlerSpec
             Some(IndexedSeq.empty),
             Some(IndexedSeq.empty),
             None,
+            None,
             None
           )
         ),
@@ -2672,6 +2678,7 @@ class DatasetHandlerSpec
             Some(IndexedSeq.empty),
             Some(IndexedSeq.empty),
             None,
+            None,
             None
           )
         ),
@@ -2684,6 +2691,7 @@ class DatasetHandlerSpec
             None,
             Some(IndexedSeq.empty),
             Some(IndexedSeq.empty),
+            None,
             None,
             None
           )
@@ -2785,6 +2793,7 @@ class DatasetHandlerSpec
             None,
             Some(IndexedSeq.empty),
             Some(IndexedSeq.empty),
+            None,
             None,
             None
           )

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DoiCollectionHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DoiCollectionHandlerSpec.scala
@@ -618,34 +618,34 @@ class DoiCollectionHandlerSpec
       val manifestJson =
         s"""
            |{
-           |  "pennsieveDatasetId": 1791,
-           |  "version": 14,
-           |  "name": "f1df25c0-f5b7-43a2-8482-250acaabfc18",
-           |  "description": "29ceef0e-bd65-45b7-a5e6-8feb8da813ea",
+           |  "pennsieveDatasetId": 3862,
+           |  "version": 3,
+           |  "name": "90acb367-515d-43b3-b88c-54403cbdc9b6",
+           |  "description": "c302d2ec-7ae6-457b-8a69-4715cac9c8aa",
            |  "creator": {
-           |    "first_name": "9ea5bebc-620a-4019-b0d9-fbe42bcb24b5",
-           |    "last_name": "13fa3d78-2bbc-4ac0-90ba-051907689dc8",
-           |    "orcid": "3510ff82-91ac-4883-a120-0d394d609ab6",
-           |    "middle_initial": "b",
-           |    "degree": "Ph.D."
+           |    "first_name": "81db83d6-ad29-43d6-97c4-500396355b38",
+           |    "last_name": "9eedf149-f13f-4c55-a3d5-a274060a58f1",
+           |    "orcid": "d54200dc-009d-4ca8-b277-ff0d5274ddd3",
+           |    "middle_initial": "0",
+           |    "degree": "M.S."
            |  },
            |  "contributors": [
            |    {
-           |      "first_name": "9ea5bebc-620a-4019-b0d9-fbe42bcb24b5",
-           |      "last_name": "13fa3d78-2bbc-4ac0-90ba-051907689dc8",
-           |      "orcid": "3510ff82-91ac-4883-a120-0d394d609ab6",
-           |      "middle_initial": "b",
-           |      "degree": "Ph.D."
+           |      "first_name": "81db83d6-ad29-43d6-97c4-500396355b38",
+           |      "last_name": "9eedf149-f13f-4c55-a3d5-a274060a58f1",
+           |      "orcid": "d54200dc-009d-4ca8-b277-ff0d5274ddd3",
+           |      "middle_initial": "0",
+           |      "degree": "M.S."
            |    }
            |  ],
            |  "sourceOrganization": "",
            |  "keywords": [
-           |    "f272254c-da93-4b8b-aba6-8aef77f10457",
-           |    "b880141d-6f8f-4441-aa1b-b4a126de19ae"
+           |    "813228ad-bd2f-42b7-acf9-70b95cb2c144",
+           |    "9d79aabf-21c2-4870-ae75-8def7d6218cf"
            |  ],
            |  "datePublished": "2025-07-07",
-           |  "license": "Apache 2.0",
-           |  "@id": "10.1111/4b5a87a7-82ca-4122-aa16-697135cd14bb",
+           |  "license": "BSD 3-Clause \\"New\\" or \\"Revised\\" License",
+           |  "@id": "10.1111/05a5a504-a0b1-4023-b788-041228f01c41",
            |  "publisher": "The University of Pennsylvania",
            |  "@context": "http://schema.org/",
            |  "@type": "Collection",
@@ -654,15 +654,17 @@ class DoiCollectionHandlerSpec
            |    {
            |      "name": "manifest.json",
            |      "path": "manifest.json",
-           |      "size": 1445,
+           |      "size": 1478,
            |      "fileType": "Json"
            |    }
            |  ],
-           |  "references": {"ids": [
-           |    "10.1111/635e620f-ca11-469b-88de-f9ad84557d45",
-           |    "10.1111/b5833ade-a29a-4d09-a040-a2b31ea54587",
-           |    "10.1111/a3222e95-e4d6-416c-9610-fac73180bbbf"
-           |  ]},
+           |  "references": {
+           |    "ids": [
+           |      "10.1111/31080ffa-858b-40f1-96b0-d042c4a67928",
+           |      "10.1111/116bd2df-0be3-4c80-9bd0-5cdb9210a414",
+           |      "10.1111/5d2ec43a-45d6-4d96-a841-371f7a30e10e"
+           |    ]
+           |  },
            |  "pennsieveSchemaVersion": "5.0"
            |}
            |""".stripMargin
@@ -671,7 +673,7 @@ class DoiCollectionHandlerSpec
         .storeDatasetMetadata(publicVersion, manifestJson)
 
       val expectedFileCount = 1
-      val expectedTotalSize = 1445
+      val expectedTotalSize = 1478
       val expectedManifestKey = s"${publicDataset.id}/manifest.json"
       val expectedManifestVersionId = TestUtilities.randomString()
 

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DoiCollectionHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DoiCollectionHandlerSpec.scala
@@ -413,5 +413,17 @@ class DoiCollectionHandlerSpec
       )
     }
 
+    "fail with Bad Request if given no DOIs" in {
+      val nonPennsieveBody = requestBody.copy(dois = Vector.empty)
+      val response = client
+        .publishDoiCollection(collectionId, nonPennsieveBody, authToken)
+        .awaitFinite()
+        .value
+
+      response shouldBe PublishDoiCollectionResponse.BadRequest(
+        "no DOIs in request"
+      )
+    }
+
   }
 }

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -461,7 +461,7 @@ class PublishHandlerSpec
     }
 
     "publish to an embargo bucket" in {
-      val expectedEmbargoReleaseDate = LocalDate.of(2025, 6, 1)
+      val expectedEmbargoReleaseDate = LocalDate.now().plusDays(30)
 
       val response = client
         .publish(
@@ -539,7 +539,7 @@ class PublishHandlerSpec
     }
 
     "correctly use custom embargo bucket" in {
-      val expectedEmbargoReleaseDate = LocalDate.of(2025, 6, 1)
+      val expectedEmbargoReleaseDate = LocalDate.now().plusDays(30)
 
       val response = client
         .publish(

--- a/server/src/test/scala/com/pennsieve/discover/handlers/SearchHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/SearchHandlerSpec.scala
@@ -158,6 +158,7 @@ class SearchHandlerSpec
               Some(Vector(PublicCollectionDTO.apply(collection))),
               Some(Vector.empty),
               None,
+              None,
               None
             )
           ),
@@ -170,6 +171,7 @@ class SearchHandlerSpec
               None,
               Some(Vector.empty),
               Some(Vector.empty),
+              None,
               None,
               None
             )

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -354,3 +354,10 @@ resource "aws_ssm_parameter" "delete_release_intermediate_file" {
   type = "String"
   value = "false"
 }
+
+// DOI Collection settings
+resource "aws_ssm_parameter" "pennsieve_doi_prefix" {
+  name = "/${var.environment_name}/${var.service_name}/pennsieve-doi-prefix"
+  type = "String"
+  value = local.pennsieve_doi_prefix
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -61,4 +61,7 @@ locals {
   }
 
   sparc_environment_name = var.environment_name == "dev" ? "dev" : "prd"
+
+  pennsieve_doi_prefix = var.environment_name == "prod" ? "10.26275" : "10.21397"
+
 }


### PR DESCRIPTION
PR to support the publication of collections created by the [collections-service](https://github.com/Pennsieve/collections-service), sometimes called DOI collections here to distinguish from older collections concept. 

So far:
- Two new tables to hold DOI collection specific details.
- New internal endpoint `POST  /collection/{collectionId}/publish` that the collection-service will call to initiate the publication of a DOI collection.
- New internal endpoint `POST /collection/{collectionId}/finalize` to be called by collections-service once it has created and uploaded a manifest file to S3 (or failed to do so).
- New optional `doiCollection` field on `PublicDatasetDTO` that is now returned by the various `GET /dataset(s)` endpoints if the public dataset is of type `collection`.

Still to do:
- New public endpoint(s) to get the contained DOIs when looking at an individual DOI collection.