### PR TITLE
Fix Missing DoiCollectionHandler routes

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/Server.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Server.scala
@@ -89,7 +89,8 @@ object Server extends App with StrictLogging {
         DatasetHandler.routes(ports),
         OrganizationHandler.routes(ports),
         FileHandler.routes(ports),
-        ReleaseHandler.routes(ports)
+        ReleaseHandler.routes(ports),
+        DoiCollectionHandler.routes(ports)
       )
     )
 


### PR DESCRIPTION
PR #125 failed to add the `DoiCollectionHandler` routes to the server. This PR is a fix for that.