### PR TITLE
DOI Collection id-space config

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -200,4 +200,10 @@ runtime-settings = {
 
 doi-collections = {
     pennsieve-doi-prefix = ${PENNSIEVE_DOI_PREFIX}
+    id-space = {
+        id = -20
+        id = ${?DOI_COLLECTIONS_ID_SPACE_ID}
+        name = "DOI Collections ID Space"
+        name = ${?DOI_COLLECTIONS_ID_SPACE_NAME}
+    }
 }

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -200,10 +200,11 @@ runtime-settings = {
 
 doi-collections = {
     pennsieve-doi-prefix = ${PENNSIEVE_DOI_PREFIX}
+    # ID-Space is the workspace that acts as the source organization for published DOI collections.
     id-space = {
         id = -20
         id = ${?DOI_COLLECTIONS_ID_SPACE_ID}
-        name = "DOI Collections ID Space"
+        name = "Publishing Collections"
         name = ${?DOI_COLLECTIONS_ID_SPACE_NAME}
     }
 }

--- a/server/src/main/scala/com/pennsieve/discover/Config.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Config.scala
@@ -131,4 +131,6 @@ case class AthenaConfig(
 
 case class RuntimeSettings(deleteReleaseIntermediateFile: Boolean)
 
-case class DoiCollections(pennsieveDoiPrefix: String)
+case class DoiCollections(pennsieveDoiPrefix: String, idSpace: IdSpace)
+
+case class IdSpace(id: Int, name: String)

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DoiCollectionHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DoiCollectionHandler.scala
@@ -48,10 +48,6 @@ import com.pennsieve.models.PublishStatus
 import io.circe.DecodingFailure
 import slick.jdbc.TransactionIsolation
 import com.pennsieve.discover.db.profile.api._
-import com.pennsieve.discover.handlers.DoiCollectionHandler.{
-  collectionOrgId,
-  collectionOrgName
-}
 import com.pennsieve.discover.notifications.{
   PushDoiRequest,
   SQSMessenger,
@@ -77,6 +73,9 @@ class DoiCollectionHandler(
     GuardrailResource.FinalizeDoiCollectionResponse
   private val pennsieveDoiPrefix =
     ports.config.doiCollections.pennsieveDoiPrefix
+
+  private val collectionOrgId = ports.config.doiCollections.idSpace.id
+  private val collectionOrgName = ports.config.doiCollections.idSpace.name
 
   override def publishDoiCollection(
     respond: GuardrailResource.PublishDoiCollectionResponse.type
@@ -346,7 +345,7 @@ class DoiCollectionHandler(
     logContext: DiscoverLogContext
   ): DBIOAction[Unit, NoStream, Effect] = {
     version.status match {
-      case PublishInProgress => DBIOAction.from(Future.successful())
+      case PublishInProgress => DBIOAction.from(Future.successful(()))
       case _ => {
         ports.log.warn(
           s"DoiCollectionHandler.checkVersionStatusForFinalize() datasetId: ${version.datasetId} version: ${version.version} is in state ${version.status}"
@@ -457,9 +456,6 @@ class DoiCollectionHandler(
 }
 
 object DoiCollectionHandler {
-  val collectionOrgId: Int = PublicDatasetDoiCollection.collectionOrgId
-  val collectionOrgName: String = PublicDatasetDoiCollection.collectionOrgName
-
   def routes(
     ports: Ports
   )(implicit

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollection.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollection.scala
@@ -15,8 +15,6 @@ case class PublicDatasetDoiCollection(
 
 object PublicDatasetDoiCollection {
 
-  val collectionOrgId = -20
-  val collectionOrgName = "DOI Collection ID Space"
   /*
    * This is required by slick when using a companion object on a case
    * class that defines a database table

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -13,4 +13,8 @@ external-publish-buckets = [
 
 doi-collections = {
     pennsieve-doi-prefix = "10.00000"
+    id-space = {
+        id = 99999
+        name = "collections id space"
+    }
 }

--- a/server/src/test/resources/config-with-external-buckets.conf
+++ b/server/src/test/resources/config-with-external-buckets.conf
@@ -172,4 +172,8 @@ runtime-settings = {
 
 doi-collections = {
     pennsieve-doi-prefix = "10.00000"
+    id-space = {
+            id = 99999
+            name = "collections id space"
+        }
 }

--- a/server/src/test/resources/config-without-external-buckets.conf
+++ b/server/src/test/resources/config-without-external-buckets.conf
@@ -161,4 +161,8 @@ runtime-settings = {
 
 doi-collections = {
     pennsieve-doi-prefix = "10.00000"
+    id-space = {
+            id = 99999
+            name = "collections id space"
+        }
 }

--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -117,7 +117,10 @@ trait ServiceSpecHarness
           "rejoin_glue_catalog.dev_s3_access_logs_db.discover"
       ),
       runtimeSettings = RuntimeSettings(deleteReleaseIntermediateFile = false),
-      doiCollections = DoiCollections(pennsieveDoiPrefix = "10.00000")
+      doiCollections = DoiCollections(
+        pennsieveDoiPrefix = "10.00000",
+        IdSpace(99999, "Test Collections ID Space")
+      )
     )
 
   def getPorts(config: Config): Ports = {

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -563,7 +563,8 @@ object TestUtilities extends AwaitableImplicits {
   }
 
   def createDoiCollectionDataset(
-    db: Database
+    db: Database,
+    idSpace: IdSpace
   )(
     name: String = "My Dataset",
     sourceDatasetId: Int = 1,
@@ -578,8 +579,8 @@ object TestUtilities extends AwaitableImplicits {
     db.run(
         PublicDatasetsMapper.createOrUpdate(
           name = name,
-          sourceOrganizationId = PublicDatasetDoiCollection.collectionOrgId,
-          sourceOrganizationName = PublicDatasetDoiCollection.collectionOrgName,
+          sourceOrganizationId = idSpace.id,
+          sourceOrganizationName = idSpace.name,
           sourceDatasetId = sourceDatasetId,
           ownerId = ownerId,
           ownerFirstName = ownerFirstName,

--- a/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetVersionsMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetVersionsMapperSpec.scala
@@ -749,10 +749,10 @@ class PublicDatasetVersionsMapperSpec
       TestUtilities.createDataset(ports.db)(sourceDatasetId = 4, name = "D")
 
     val ds5 =
-      TestUtilities.createDoiCollectionDataset(ports.db)(
-        sourceDatasetId = 5,
-        name = "E"
-      )
+      TestUtilities.createDoiCollectionDataset(
+        ports.db,
+        ports.config.doiCollections.idSpace
+      )(sourceDatasetId = 5, name = "E")
 
     val ds1_v1 = TestUtilities.createNewDatasetVersion(ports.db)(
       id = ds1.id,

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -384,7 +384,10 @@ class DatasetHandlerSpec
     "return a published DOI collection dataset with auth" in {
 
       val collectionDataset =
-        TestUtilities.createDoiCollectionDataset(ports.db)()
+        TestUtilities.createDoiCollectionDataset(
+          ports.db,
+          ports.config.doiCollections.idSpace
+        )()
 
       val collectionDatasetV1 =
         TestUtilities.createNewDatasetVersion(ports.db)(
@@ -466,7 +469,10 @@ class DatasetHandlerSpec
     "return a published DOI collection dataset without auth" in {
 
       val collectionDataset =
-        TestUtilities.createDoiCollectionDataset(ports.db)()
+        TestUtilities.createDoiCollectionDataset(
+          ports.db,
+          ports.config.doiCollections.idSpace
+        )()
 
       val collectionDatasetV1 =
         TestUtilities.createNewDatasetVersion(ports.db)(
@@ -611,7 +617,10 @@ class DatasetHandlerSpec
 
     "get a DOI collection dataset" in {
 
-      val dataset = TestUtilities.createDoiCollectionDataset(ports.db)()
+      val dataset = TestUtilities.createDoiCollectionDataset(
+        ports.db,
+        ports.config.doiCollections.idSpace
+      )()
       val version = {
         TestUtilities.createNewDatasetVersion(ports.db)(
           id = dataset.id,
@@ -690,10 +699,10 @@ class DatasetHandlerSpec
         TestUtilities.createDataset(ports.db)(sourceDatasetId = 3, name = "C")
       val ds4 =
         TestUtilities.createDataset(ports.db)(sourceDatasetId = 4, name = "D")
-      val ds5 = TestUtilities.createDoiCollectionDataset(ports.db)(
-        sourceDatasetId = 5,
-        name = "E"
-      )
+      val ds5 = TestUtilities.createDoiCollectionDataset(
+        ports.db,
+        ports.config.doiCollections.idSpace
+      )(sourceDatasetId = 5, name = "E")
 
       val ds1_v1 = TestUtilities.createNewDatasetVersion(ports.db)(
         id = ds1.id,
@@ -1184,7 +1193,10 @@ class DatasetHandlerSpec
     "return a DOI collection dataset version" in {
 
       val collectionDataset =
-        TestUtilities.createDoiCollectionDataset(ports.db)()
+        TestUtilities.createDoiCollectionDataset(
+          ports.db,
+          ports.config.doiCollections.idSpace
+        )()
       val collectionDatasetV1 =
         TestUtilities.createNewDatasetVersion(ports.db)(
           id = collectionDataset.id,
@@ -1298,7 +1310,10 @@ class DatasetHandlerSpec
       // Placed here, before Dataset 3 (embargoed) so that 3 is still the newest dataset
       // to keep the order simple when checking below. (by default datasets returned in desc pub date order)
       val publicDataset4 =
-        TestUtilities.createDoiCollectionDataset(ports.db)(sourceDatasetId = 4)
+        TestUtilities.createDoiCollectionDataset(
+          ports.db,
+          ports.config.doiCollections.idSpace
+        )(sourceDatasetId = 4)
       val publicDataset4_V1 = TestUtilities.createNewDatasetVersion(ports.db)(
         id = publicDataset4.id,
         status = PublishSucceeded

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -61,8 +61,8 @@ resource "aws_ssm_parameter" "doi_service_host" {
 // NEW RELIC CONFIGURATION
 
 resource "aws_ssm_parameter" "java_opts" {
-  name  = "/${var.environment_name}/${var.service_name}/java-opts"
-  type  = "String"
+  name = "/${var.environment_name}/${var.service_name}/java-opts"
+  type = "String"
   value = join(" ", local.java_opts)
 }
 
@@ -350,14 +350,26 @@ resource "aws_ssm_parameter" "rejoin_bucket_access_glue_table" {
 
 // Runtime settings
 resource "aws_ssm_parameter" "delete_release_intermediate_file" {
-  name = "/${var.environment_name}/${var.service_name}/delete-release-intermediate-file"
-  type = "String"
+  name  = "/${var.environment_name}/${var.service_name}/delete-release-intermediate-file"
+  type  = "String"
   value = "false"
 }
 
 // DOI Collection settings
 resource "aws_ssm_parameter" "pennsieve_doi_prefix" {
-  name = "/${var.environment_name}/${var.service_name}/pennsieve-doi-prefix"
-  type = "String"
+  name  = "/${var.environment_name}/${var.service_name}/pennsieve-doi-prefix"
+  type  = "String"
   value = local.pennsieve_doi_prefix
+}
+
+resource "aws_ssm_parameter" "doi_collections_id_space_id" {
+  name  = "/${var.environment_name}/${var.service_name}/doi-collections-id-space-id"
+  type  = "String"
+  value = var.doi_collections_id_space_id
+}
+
+resource "aws_ssm_parameter" "doi_collections_id_space_name" {
+  name  = "/${var.environment_name}/${var.service_name}/doi-collections-id-space-name"
+  type  = "String"
+  value = var.doi_collections_id_space_name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,6 +39,14 @@ variable "rejoin_glue_catalog" {
   default = "rejoin_glue_catalog"
 }
 
+// doi_collections_id_space_id is the id of the workspace that acts
+// as the id-space for published collections
+variable "doi_collections_id_space_id" {}
+
+// doi_collections_id_space_name is the name of the workspace that acts
+// as the id-space for published collections
+variable "doi_collections_id_space_name" {}
+
 locals {
   java_opts = [
     "-javaagent:/app/newrelic.jar",
@@ -48,7 +56,7 @@ locals {
   ]
 
   service = element(split("-", var.service_name), 0)
-  tier    = element(split("-", var.service_name), 1)
+  tier = element(split("-", var.service_name), 1)
 
   hosted_zone = data.terraform_remote_state.account.outputs.public_hosted_zone_id
   domain_name = data.terraform_remote_state.account.outputs.domain_name


### PR DESCRIPTION
PR moves the id and name of the workspace that is used for the source org when publishing DOI collections from being hardcoded to a config setting.

For Terraform plan see https://github.com/Pennsieve/infrastructure/pull/328