### PR TITLE
Log manifest decoding error

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/S3StreamClient.scala
@@ -1500,7 +1500,10 @@ class AlpakkaS3StreamClient(
         case Some(byteString) =>
           decode[DatasetMetadata](
             byteString.decodeString(akka.util.ByteString.UTF_8)
-          ).fold(l => None, r => Some(r))
+          ).fold(l => {
+            logger.error("error decoding DatasetMetadata; returning None", l)
+            None
+          }, r => Some(r))
         case None => None
       }
     } yield output


### PR DESCRIPTION
The method used to load dataset manifest files from S3 returns `None` both when the file cannot be found in S3 and also when an error occurs when decoding the file to a `DatasetManifest` instance. This makes it hard to figure out what the true issue is. 

PR adds a error log call to log the decoding error so this problem is not mistaken for a key-not-found issue.
