### PR TITLE
More DOI Collections publishing support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -382,22 +382,22 @@ lazy val client = project
         ScalaClient(
           file("openapi/discover-service.yml"),
           pkg = "com.pennsieve.discover.client",
-          modules = List("akka-http", "circe-0.11")
+          modules = List("akka-http", "circe-0.11"),
         ),
         ScalaClient(
           file("openapi/discover-service-internal.yml"),
           pkg = "com.pennsieve.discover.client",
-          modules = List("akka-http", "circe-0.11")
+          modules = List("akka-http", "circe-0.11"),
         )
       ),
       List(
         ScalaClient(
           file("openapi/discover-service.yml"),
-          pkg = "com.pennsieve.discover.client"
+          pkg = "com.pennsieve.discover.client",
         ),
         ScalaClient(
           file("openapi/discover-service-internal.yml"),
-          pkg = "com.pennsieve.discover.client"
+          pkg = "com.pennsieve.discover.client",
         )
       )
     )

--- a/build.sbt
+++ b/build.sbt
@@ -382,22 +382,22 @@ lazy val client = project
         ScalaClient(
           file("openapi/discover-service.yml"),
           pkg = "com.pennsieve.discover.client",
-          modules = List("akka-http", "circe-0.11"),
+          modules = List("akka-http", "circe-0.11")
         ),
         ScalaClient(
           file("openapi/discover-service-internal.yml"),
           pkg = "com.pennsieve.discover.client",
-          modules = List("akka-http", "circe-0.11"),
+          modules = List("akka-http", "circe-0.11")
         )
       ),
       List(
         ScalaClient(
           file("openapi/discover-service.yml"),
-          pkg = "com.pennsieve.discover.client",
+          pkg = "com.pennsieve.discover.client"
         ),
         ScalaClient(
           file("openapi/discover-service-internal.yml"),
-          pkg = "com.pennsieve.discover.client",
+          pkg = "com.pennsieve.discover.client"
         )
       )
     )

--- a/client/src/main/scala/com/pennsieve/discover/models/DOIInformation.scala
+++ b/client/src/main/scala/com/pennsieve/discover/models/DOIInformation.scala
@@ -2,7 +2,7 @@
 
 package com.pennsieve.discover.models
 
-import io.circe.{ Decoder, Encoder }
+import io.circe.{ Decoder, Encoder, Json }
 import io.circe.generic.semiauto._
 import enumeratum.{ CirceEnum, Enum, EnumEntry }
 

--- a/client/src/main/scala/com/pennsieve/discover/models/DOIInformation.scala
+++ b/client/src/main/scala/com/pennsieve/discover/models/DOIInformation.scala
@@ -2,9 +2,15 @@
 
 package com.pennsieve.discover.models
 
+import com.pennsieve.discover.models.DOIData.{
+  FromExternalDoiData,
+  FromPublicDTO,
+  FromTombstoneDTO
+}
+import enumeratum.{ CirceEnum, Enum, EnumEntry }
 import io.circe.{ Decoder, Encoder, Json }
 import io.circe.generic.semiauto._
-import enumeratum.{ CirceEnum, Enum, EnumEntry }
+import io.circe.syntax.EncoderOps
 
 sealed trait DOIData
 
@@ -39,6 +45,37 @@ object DOIInformationSource
 case class DOIInformation(source: DOIInformationSource, data: DOIData)
 
 object DOIInformation {
-  implicit val encoder: Encoder[DOIInformation] = deriveEncoder
-  implicit val decoder: Decoder[DOIInformation] = deriveDecoder
+  // Custom encoder to avoid nested Json DOIData objects
+  implicit val encoder: Encoder[DOIInformation] = Encoder.instance { outer =>
+    Json.obj("source" -> outer.source.asJson, "data" -> {
+      outer.data match {
+        case FromPublicDTO(publicDTO) => publicDTO.asJson
+        case FromTombstoneDTO(tombstoneDTO) => tombstoneDTO.asJson
+        case FromExternalDoiData(externalDTO) => externalDTO.asJson
+      }
+    })
+  }
+  implicit val decoder: Decoder[DOIInformation] = Decoder.instance { cursor =>
+    for {
+      source <- cursor.get[DOIInformationSource]("source")
+      data <- source match {
+        case DOIInformationSource.Pennsieve =>
+          cursor
+            .get[com.pennsieve.discover.client.definitions.PublicDatasetDto](
+              "data"
+            )
+            .map(FromPublicDTO)
+        case DOIInformationSource.PennsieveUnpublished =>
+          cursor
+            .get[com.pennsieve.discover.client.definitions.TombstoneDto]("data")
+            .map(FromTombstoneDTO)
+        case DOIInformationSource.External =>
+          cursor
+            .get[com.pennsieve.discover.client.definitions.ExternalDoiData](
+              "data"
+            )
+            .map(FromExternalDoiData)
+      }
+    } yield DOIInformation(source, data)
+  }
 }

--- a/client/src/main/scala/com/pennsieve/discover/models/DOIInformation.scala
+++ b/client/src/main/scala/com/pennsieve/discover/models/DOIInformation.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto._
+import enumeratum.{ CirceEnum, Enum, EnumEntry }
+
+sealed trait DOIData
+
+object DOIData {
+  case class FromPublicDTO(
+    value: com.pennsieve.discover.client.definitions.PublicDatasetDto
+  ) extends DOIData
+  case class FromTombstoneDTO(
+    value: com.pennsieve.discover.client.definitions.TombstoneDto
+  ) extends DOIData
+  case class FromExternalDoiData(
+    value: com.pennsieve.discover.client.definitions.ExternalDoiData
+  ) extends DOIData
+
+  implicit val encoder: Encoder[DOIData] = deriveEncoder
+  implicit val decoder: Decoder[DOIData] = deriveDecoder
+}
+
+sealed trait DOIInformationSource extends EnumEntry
+
+object DOIInformationSource
+    extends Enum[DOIInformationSource]
+    with CirceEnum[DOIInformationSource] {
+  val values: IndexedSeq[DOIInformationSource] = findValues
+  case object Pennsieve extends DOIInformationSource
+  case object PennsieveUnpublished extends DOIInformationSource
+  case object External extends DOIInformationSource
+}
+
+// Defining this ourselves instead of letting Guardrail create it because the
+// version we are using cannot handle polymorphism via OpenAPI oneOf
+case class DOIInformation(source: DOIInformationSource, data: DOIData)
+
+object DOIInformation {
+  implicit val encoder: Encoder[DOIInformation] = deriveEncoder
+  implicit val decoder: Decoder[DOIInformation] = deriveDecoder
+}

--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -711,6 +711,81 @@ paths:
               schema:
                 $ref: "#/components/schemas/TombstoneDTO"
 
+  "/datasets/{datasetId}/versions/{versionId}/dois":
+    get:
+      tags:
+        - Datasets
+      security: [ ]
+      summary: get a page of DOIs contained in a dataset
+      operationId: getDoiPage
+      x-scala-package: dataset
+      description: >
+        Return a page of info on the DOIs in this collection.
+        Will be empty unless datasetType is collection.
+      parameters:
+        - name: datasetId
+          in: path
+          description: dataset id
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: versionId
+          in: path
+          description: version number
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: limit
+          in: query
+          description: max number of DOIs returned
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 10
+        - name: offset
+          in: query
+          description: offset used for pagination of results
+          required: false
+          schema:
+            type: integer
+            format: int32
+            default: 0
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DOIPage"
+        "401":
+          description: dataset is under embargo
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: dataset is under embargo
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: resource not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "410":
+          description: dataset unpublished
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TombstoneDTO"
+
+
   "/datasets/{datasetId}/versions/{versionId}/files/download-manifest":
     post:
       tags:
@@ -1679,6 +1754,41 @@ components:
         size:
           description: number of DOIs in the collection
           type: integer
+
+    DOIPage:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/GenericResponsePage"
+        - type: object
+          required:
+            - dois
+          properties:
+            dois:
+              type: array
+              items:
+                $ref: "#/components/schemas/DOIInformation"
+
+
+    DOIInformation:
+      type: object
+      description: >
+        Information about the DOI retrieved either from Pennsieve or
+        an external source like DataCite.
+        The source field will be a DOIInformationSource.
+        The data field will be either a PublicDatasetDTO (source == Pennsieve), 
+        TombstoneDTO (source == PennsieveUnpublished), or ExternalDOIData (source == External)
+      x-scala-type: com.pennsieve.discover.models.DOIInformation
+
+    ExternalDOIData:
+      description: >
+        A placeholder for what we will return if DOI collections are allowed to
+        contain non-Pennsieve DOIs.
+      type: object
+      required:
+        - doi
+      properties:
+        doi:
+          type: string
 
     GenericResponsePage:
       description: >

--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -1668,6 +1668,7 @@ components:
       type: object
       required:
         - banners
+        - size
       properties:
         banners:
           description: at most 4 banner URLs
@@ -1675,6 +1676,9 @@ components:
           type: array
           items:
             type: string
+        size:
+          description: number of DOIs in the collection
+          type: integer
 
     GenericResponsePage:
       description: >

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisTable.scala
@@ -77,8 +77,8 @@ object PublicDatasetDoiCollectionDoisMapper
   def getDOIPage(
     datasetId: Int,
     datasetVersion: Int,
-    limit: Int = 10,
-    offset: Int = 0
+    limit: Int,
+    offset: Int
   )(implicit
     executionContext: ExecutionContext
   ): DBIOAction[PagedDoiResult, NoStream, Effect.Read] = {

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetVersionsTable.scala
@@ -163,7 +163,7 @@ object PublicDatasetVersionsMapper
     collections: IndexedSeq[PublicCollection],
     externalPublications: IndexedSeq[PublicExternalPublication],
     release: Option[PublicDatasetRelease],
-    doiCollection: Option[PublicDatasetDoiCollection]
+    doiCollection: Option[PublicDatasetDoiCollectionWithSize]
   )
 
   case class GetDatasetsByDoiResult(
@@ -214,7 +214,7 @@ object PublicDatasetVersionsMapper
 
       releasesMap <- PublicDatasetReleaseMapper.getFor(publishedVersions)
 
-      doiCollectionsMap <- PublicDatasetDoiCollectionsMapper.getFor(
+      doiCollectionsMap <- PublicDatasetDoiCollectionsMapper.getForWithSize(
         publishedVersions
       )
 
@@ -508,7 +508,7 @@ object PublicDatasetVersionsMapper
       (PublicDataset, PublicDatasetVersion, IndexedSeq[PublicContributor],
         Option[Sponsorship], Option[Revision], IndexedSeq[PublicCollection],
         IndexedSeq[PublicExternalPublication], Option[PublicDatasetRelease],
-        Option[PublicDatasetDoiCollection])
+        Option[PublicDatasetDoiCollectionWithSize])
     ]
   )
 
@@ -601,7 +601,7 @@ object PublicDatasetVersionsMapper
         }
       )
 
-      doiCollectionsMap <- PublicDatasetDoiCollectionsMapper.getFor(
+      doiCollectionsMap <- PublicDatasetDoiCollectionsMapper.getForWithSize(
         pagedDatasetsWithSponsorships.map {
           case ((dataset, version), _) => (dataset, version)
         }

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
@@ -132,7 +132,7 @@ class DatasetHandler(
     version: PublicDatasetVersion,
     preview: Option[DatasetPreview] = None,
     release: Option[PublicDatasetRelease] = None,
-    doiCollection: Option[PublicDatasetDoiCollection] = None
+    doiCollection: Option[PublicDatasetDoiCollectionWithSize] = None
   ): DBIO[PublicDatasetDto] =
     for {
 
@@ -259,7 +259,7 @@ class DatasetHandler(
         }
 
       release <- PublicDatasetReleaseMapper.get(dataset.id, version.version)
-      doiCollection <- PublicDatasetDoiCollectionsMapper.get(
+      doiCollection <- PublicDatasetDoiCollectionsMapper.getWithSize(
         dataset.id,
         version.version
       )
@@ -331,7 +331,7 @@ class DatasetHandler(
 
       release <- PublicDatasetReleaseMapper.get(dataset.id, version.version)
 
-      doiCollection <- PublicDatasetDoiCollectionsMapper.get(
+      doiCollection <- PublicDatasetDoiCollectionsMapper.getWithSize(
         dataset.id,
         version.version
       )
@@ -547,7 +547,7 @@ class DatasetHandler(
 
       release <- PublicDatasetReleaseMapper.get(dataset.id, version.version)
 
-      doiCollection <- PublicDatasetDoiCollectionsMapper.get(
+      doiCollection <- PublicDatasetDoiCollectionsMapper.getWithSize(
         dataset.id,
         version.version
       )

--- a/server/src/main/scala/com/pennsieve/discover/models/DOIInformation.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/DOIInformation.scala
@@ -1,0 +1,44 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.models
+
+import enumeratum.{ CirceEnum, Enum, EnumEntry }
+import io.circe.{ Decoder, Encoder }
+import io.circe.generic.semiauto._
+
+sealed trait DOIData
+
+object DOIData {
+  case class FromPublicDTO(
+    value: com.pennsieve.discover.server.definitions.PublicDatasetDto
+  ) extends DOIData
+  case class FromTombstoneDTO(
+    value: com.pennsieve.discover.server.definitions.TombstoneDto
+  ) extends DOIData
+  case class FromExternalDoiData(
+    value: com.pennsieve.discover.server.definitions.ExternalDoiData
+  ) extends DOIData
+
+  implicit val encoder: Encoder[DOIData] = deriveEncoder
+  implicit val decoder: Decoder[DOIData] = deriveDecoder
+}
+
+sealed trait DOIInformationSource extends EnumEntry
+
+object DOIInformationSource
+    extends Enum[DOIInformationSource]
+    with CirceEnum[DOIInformationSource] {
+  val values: IndexedSeq[DOIInformationSource] = findValues
+  case object Pennsieve extends DOIInformationSource
+  case object PennsieveUnpublished extends DOIInformationSource
+  case object External extends DOIInformationSource
+}
+
+// Defining this ourselves instead of letting Guardrail create it because the
+// version we are using cannot handle polymorphism via OpenAPI oneOf
+case class DOIInformation(source: DOIInformationSource, data: DOIData)
+
+object DOIInformation {
+  implicit val encoder: Encoder[DOIInformation] = deriveEncoder
+  implicit val decoder: Decoder[DOIInformation] = deriveDecoder
+}

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDTO.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDTO.scala
@@ -30,10 +30,12 @@ object PublicDatasetDTO {
     }
 
   private def doiCollectionInfo(
-    doiCollection: Option[PublicDatasetDoiCollection]
+    doiCollection: Option[PublicDatasetDoiCollectionWithSize]
   ): Option[definitions.DoiCollectionInfo] =
     doiCollection.map(
-      c => definitions.DoiCollectionInfo(banners = c.banners.toVector)
+      c =>
+        definitions
+          .DoiCollectionInfo(banners = c.banners.toVector, size = c.size)
     )
 
   def apply(
@@ -48,7 +50,7 @@ object PublicDatasetDTO {
     ],
     datasetPreview: Option[DatasetPreview],
     release: Option[PublicDatasetRelease],
-    doiCollection: Option[PublicDatasetDoiCollection]
+    doiCollection: Option[PublicDatasetDoiCollectionWithSize]
   )(implicit
     config: Config
   ): definitions.PublicDatasetDto =
@@ -160,7 +162,7 @@ object PublicDatasetDTO {
     externalPublications: Seq[PublicExternalPublication],
     datasetPreview: Option[DatasetPreview],
     release: Option[PublicDatasetRelease] = None,
-    doiCollection: Option[PublicDatasetDoiCollection] = None
+    doiCollection: Option[PublicDatasetDoiCollectionWithSize] = None
   )(implicit
     config: Config
   ): definitions.PublicDatasetDto = {

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollection.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDatasetDoiCollection.scala
@@ -23,3 +23,13 @@ object PublicDatasetDoiCollection {
     (Int, Int, Int, List[String], OffsetDateTime, OffsetDateTime)
   ) => PublicDatasetDoiCollection = (this.apply _).tupled
 }
+
+case class PublicDatasetDoiCollectionWithSize(
+  id: Int = 0,
+  datasetId: Int,
+  datasetVersion: Int,
+  banners: List[String] = List.empty,
+  size: Int = 0,
+  createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
+  updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
+)

--- a/server/src/test/scala/com/pennsieve/discover/DockerPostgresService.scala
+++ b/server/src/test/scala/com/pennsieve/discover/DockerPostgresService.scala
@@ -42,7 +42,7 @@ trait DockerPostgresService extends DockerKit {
     TestPostgresConfiguration.freshPostgresConfiguration
 
   val postgresContainer: DockerContainer =
-    DockerContainer("postgres:9.6")
+    DockerContainer("postgres:16.8")
       .withPorts(
         (
           TestPostgresConfiguration.advertisedPort,

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -605,12 +605,15 @@ object TestUtilities extends AwaitableImplicits {
       s"https://images.example.com/${randomString()}/${randomString()}.jpg"
     )
 
+  def randomPennsieveDoi(doiCollections: DoiCollections): String =
+    s"${doiCollections.pennsieveDoiPrefix}/${TestUtilities.randomString()}"
+
   def createDatasetDoiCollection(
     db: Database
   )(
     datasetId: Int,
     datasetVersion: Int,
-    banners: List[String]
+    banners: List[String] = TestUtilities.randomBannerUrls
   )(implicit
     executionContext: ExecutionContext
   ): PublicDatasetDoiCollection = {

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -626,6 +626,30 @@ object TestUtilities extends AwaitableImplicits {
       .await
   }
 
+  def addDoiCollectionDois(
+    db: Database
+  )(
+    doiCollection: PublicDatasetDoiCollection,
+    dois: List[String]
+  )(implicit
+    executionContext: ExecutionContext
+  ): PublicDatasetDoiCollectionWithSize = {
+    db.run(
+        PublicDatasetDoiCollectionDoisMapper
+          .addDOIs(doiCollection.datasetId, doiCollection.datasetVersion, dois)
+      )
+      .await
+    PublicDatasetDoiCollectionWithSize(
+      id = doiCollection.id,
+      datasetId = doiCollection.datasetId,
+      datasetVersion = doiCollection.datasetVersion,
+      banners = doiCollection.banners,
+      size = dois.size,
+      createdAt = doiCollection.createdAt,
+      updatedAt = doiCollection.updatedAt
+    )
+  }
+
   def internalAndPublicContributorsMatch(
     datasetId: Int,
     versionId: Int,

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -3,6 +3,7 @@
 package com.pennsieve.discover
 
 import akka.Done
+import com.pennsieve.discover.client.definitions.InternalContributor
 import com.pennsieve.discover.db._
 import com.pennsieve.discover.db.profile.api._
 import com.pennsieve.discover.models._
@@ -20,6 +21,7 @@ import com.spotify.docker.client.DefaultDockerClient
 import com.spotify.docker.client.exceptions.DockerException
 import com.whisk.docker.DockerFactory
 import com.whisk.docker.impl.spotify.SpotifyDockerFactory
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 import java.nio.file.{ Files, Path }
 import java.util.UUID
@@ -622,6 +624,28 @@ object TestUtilities extends AwaitableImplicits {
         )
       )
       .await
+  }
+
+  def internalAndPublicContributorsMatch(
+    datasetId: Int,
+    versionId: Int,
+    internal: List[InternalContributor],
+    public: List[PublicContributor]
+  ): Unit = {
+    internal.size shouldBe public.size
+    internal.zip(public).foreach {
+      case (i, p) =>
+        p.firstName shouldBe i.firstName
+        p.middleInitial shouldBe i.middleInitial
+        p.lastName shouldBe i.lastName
+        p.degree shouldBe i.degree
+        p.orcid shouldBe i.orcid
+        p.datasetId shouldBe datasetId
+        p.versionId shouldBe versionId
+        p.sourceContributorId shouldBe i.id
+        p.sourceUserId shouldBe i.userId
+    }
+
   }
 
   /**

--- a/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisMapperSpec.scala
@@ -139,7 +139,8 @@ class PublicDatasetDoiCollectionDoisMapperSpec
           PublicDatasetDoiCollectionDoisMapper.getDOIPage(
             datasetId = dataset1.id,
             datasetVersion = dataset1V.version,
-            limit = 0
+            limit = 0,
+            offset = 0
           )
         )
         .awaitFinite()

--- a/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisMapperSpec.scala
@@ -1,0 +1,101 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.db
+
+import com.pennsieve.discover.{ ServiceSpecHarness, TestUtilities }
+import com.pennsieve.test.AwaitableImplicits
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class PublicDatasetDoiCollectionDoisMapperSpec
+    extends AnyWordSpec
+    with ServiceSpecHarness
+    with AwaitableImplicits
+    with Matchers {
+
+  "PublicDatasetDoiCollectionDoisMapper" should {
+
+    case class PageParams(limit: Int, offset: Int)
+
+    "get a page of DOIs" in {
+      val dataset1 = TestUtilities.createDoiCollectionDataset(
+        ports.db,
+        ports.config.doiCollections.idSpace
+      )(name = "dataset 1", sourceDatasetId = 1)
+      val dataset1V =
+        TestUtilities.createNewDatasetVersion(ports.db)(dataset1.id)
+
+      TestUtilities.createDatasetDoiCollection(ports.db)(
+        datasetId = dataset1V.datasetId,
+        datasetVersion = dataset1V.version,
+        banners = TestUtilities.randomBannerUrls
+      )
+
+      val dataset1VDois = List(
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString()
+      )
+
+      ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.addDOIs(
+            datasetId = dataset1V.datasetId,
+            datasetVersion = dataset1V.version,
+            dois = dataset1VDois
+          )
+        )
+        .awaitFinite()
+
+      val dataset2 = TestUtilities.createDoiCollectionDataset(
+        ports.db,
+        ports.config.doiCollections.idSpace
+      )(name = "dataset 2", sourceDatasetId = 2)
+      val dataset2V =
+        TestUtilities.createNewDatasetVersion(ports.db)(dataset2.id)
+
+      TestUtilities.createDatasetDoiCollection(ports.db)(
+        datasetId = dataset2V.datasetId,
+        datasetVersion = dataset2V.version,
+        banners = TestUtilities.randomBannerUrls
+      )
+
+      ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.addDOIs(
+            datasetId = dataset2V.datasetId,
+            datasetVersion = dataset2V.version,
+            dois = List(TestUtilities.randomString())
+          )
+        )
+        .awaitFinite()
+
+      val firstPageParams = PageParams(limit = 3, offset = 0)
+      val firstPage = ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.getDOIPage(
+            datasetId = dataset1.id,
+            datasetVersion = dataset1V.version,
+            limit = firstPageParams.limit,
+            offset = firstPageParams.offset
+          )
+        )
+        .awaitFinite()
+
+      firstPage shouldBe PagedDoiResult(
+        limit = firstPageParams.limit,
+        offset = firstPageParams.offset,
+        dataset1VDois.size,
+        dataset1VDois.slice(
+          firstPageParams.offset,
+          firstPageParams.offset + firstPageParams.limit
+        )
+      )
+
+    }
+  }
+}

--- a/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetDoiCollectionDoisMapperSpec.scala
@@ -17,7 +17,7 @@ class PublicDatasetDoiCollectionDoisMapperSpec
 
     case class PageParams(limit: Int, offset: Int)
 
-    "get a page of DOIs" in {
+    "support paginating through all of the DOIs in a DoiCollection" in {
       val dataset1 = TestUtilities.createDoiCollectionDataset(
         ports.db,
         ports.config.doiCollections.idSpace
@@ -74,28 +74,221 @@ class PublicDatasetDoiCollectionDoisMapperSpec
         )
         .awaitFinite()
 
-      val firstPageParams = PageParams(limit = 3, offset = 0)
-      val firstPage = ports.db
+      val limit = 3
+      for (offset <- 0 until 7 by limit) {
+        val pageParams = PageParams(limit = limit, offset = offset)
+        val page = ports.db
+          .run(
+            PublicDatasetDoiCollectionDoisMapper.getDOIPage(
+              datasetId = dataset1.id,
+              datasetVersion = dataset1V.version,
+              limit = pageParams.limit,
+              offset = pageParams.offset
+            )
+          )
+          .awaitFinite()
+
+        page shouldBe PagedDoiResult(
+          limit = pageParams.limit,
+          offset = pageParams.offset,
+          dataset1VDois.size,
+          dataset1VDois
+            .slice(pageParams.offset, pageParams.offset + pageParams.limit)
+        )
+
+      }
+
+    }
+
+    "give correct totalCount when limit is zero" in {
+      val dataset1 = TestUtilities.createDoiCollectionDataset(
+        ports.db,
+        ports.config.doiCollections.idSpace
+      )(name = "dataset 1", sourceDatasetId = 1)
+      val dataset1V =
+        TestUtilities.createNewDatasetVersion(ports.db)(dataset1.id)
+
+      TestUtilities.createDatasetDoiCollection(ports.db)(
+        datasetId = dataset1V.datasetId,
+        datasetVersion = dataset1V.version,
+        banners = TestUtilities.randomBannerUrls
+      )
+
+      val dataset1VDois = List(
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString()
+      )
+
+      ports.db
         .run(
-          PublicDatasetDoiCollectionDoisMapper.getDOIPage(
-            datasetId = dataset1.id,
+          PublicDatasetDoiCollectionDoisMapper.addDOIs(
+            datasetId = dataset1V.datasetId,
             datasetVersion = dataset1V.version,
-            limit = firstPageParams.limit,
-            offset = firstPageParams.offset
+            dois = dataset1VDois
           )
         )
         .awaitFinite()
 
-      firstPage shouldBe PagedDoiResult(
-        limit = firstPageParams.limit,
-        offset = firstPageParams.offset,
-        dataset1VDois.size,
-        dataset1VDois.slice(
-          firstPageParams.offset,
-          firstPageParams.offset + firstPageParams.limit
+      val page = ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.getDOIPage(
+            datasetId = dataset1.id,
+            datasetVersion = dataset1V.version,
+            limit = 0
+          )
         )
+        .awaitFinite()
+
+      page shouldBe PagedDoiResult(
+        limit = 0,
+        offset = 0,
+        dataset1VDois.size,
+        List.empty
       )
 
     }
+
+    "give correct totalCount when offset >= number of DOIs" in {
+      val dataset1 = TestUtilities.createDoiCollectionDataset(
+        ports.db,
+        ports.config.doiCollections.idSpace
+      )(name = "dataset 1", sourceDatasetId = 1)
+      val dataset1V =
+        TestUtilities.createNewDatasetVersion(ports.db)(dataset1.id)
+
+      TestUtilities.createDatasetDoiCollection(ports.db)(
+        datasetId = dataset1V.datasetId,
+        datasetVersion = dataset1V.version,
+        banners = TestUtilities.randomBannerUrls
+      )
+
+      val dataset1VDois = List(
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString()
+      )
+
+      ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.addDOIs(
+            datasetId = dataset1V.datasetId,
+            datasetVersion = dataset1V.version,
+            dois = dataset1VDois
+          )
+        )
+        .awaitFinite()
+
+      val limit = 10
+      val offset = dataset1VDois.size
+
+      val page = ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.getDOIPage(
+            datasetId = dataset1.id,
+            datasetVersion = dataset1V.version,
+            limit = limit,
+            offset = offset
+          )
+        )
+        .awaitFinite()
+
+      page shouldBe PagedDoiResult(
+        limit = limit,
+        offset = offset,
+        dataset1VDois.size,
+        List.empty
+      )
+
+    }
+
+    "return the correct number of DOIs" in {
+      val dataset1 = TestUtilities.createDoiCollectionDataset(
+        ports.db,
+        ports.config.doiCollections.idSpace
+      )(name = "dataset 1", sourceDatasetId = 1)
+      val dataset1V =
+        TestUtilities.createNewDatasetVersion(ports.db)(dataset1.id)
+
+      TestUtilities.createDatasetDoiCollection(ports.db)(
+        datasetId = dataset1V.datasetId,
+        datasetVersion = dataset1V.version,
+        banners = TestUtilities.randomBannerUrls
+      )
+
+      val dataset1VDois = List(
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString()
+      )
+
+      ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.addDOIs(
+            datasetId = dataset1V.datasetId,
+            datasetVersion = dataset1V.version,
+            dois = dataset1VDois
+          )
+        )
+        .awaitFinite()
+
+      val dataset2 = TestUtilities.createDoiCollectionDataset(
+        ports.db,
+        ports.config.doiCollections.idSpace
+      )(name = "dataset 2", sourceDatasetId = 2)
+      val dataset2V =
+        TestUtilities.createNewDatasetVersion(ports.db)(dataset2.id)
+
+      TestUtilities.createDatasetDoiCollection(ports.db)(
+        datasetId = dataset2V.datasetId,
+        datasetVersion = dataset2V.version,
+        banners = TestUtilities.randomBannerUrls
+      )
+
+      val dataset2VDois = List(TestUtilities.randomString())
+
+      ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.addDOIs(
+            datasetId = dataset2V.datasetId,
+            datasetVersion = dataset2V.version,
+            dois = dataset2VDois
+          )
+        )
+        .awaitFinite()
+
+      ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.getDOICount(
+            datasetId = dataset1V.datasetId,
+            datasetVersion = dataset1V.version
+          )
+        )
+        .awaitFinite() shouldBe dataset1VDois.size
+
+      ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper.getDOICount(
+            datasetId = dataset2V.datasetId,
+            datasetVersion = dataset2V.version
+          )
+        )
+        .awaitFinite() shouldBe dataset2VDois.size
+
+    }
+
   }
+
 }

--- a/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetVersionsMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/PublicDatasetVersionsMapperSpec.scala
@@ -7,6 +7,7 @@ import com.pennsieve.discover.models.{
   OrderBy,
   OrderDirection,
   PublicDataset,
+  PublicDatasetDoiCollectionWithSize,
   PublicDatasetVersion,
   PublishingWorkflow,
   S3Key
@@ -882,6 +883,28 @@ class PublicDatasetVersionsMapperSpec
         banners = TestUtilities.randomBannerUrls
       )
 
+    val ds5_v1_dois =
+      List(
+        TestUtilities.randomString(),
+        TestUtilities.randomString(),
+        TestUtilities.randomString()
+      )
+
+    ports.db.run(
+      PublicDatasetDoiCollectionDoisMapper
+        .addDOIs(ds5.id, ds5_v1.version, ds5_v1_dois)
+    )
+
+    val ds5_v1_doiCollectionWithSize = PublicDatasetDoiCollectionWithSize(
+      id = ds5_v1_doiCollection.id,
+      datasetId = ds5_v1_doiCollection.datasetId,
+      datasetVersion = ds5_v1_doiCollection.datasetVersion,
+      banners = ds5_v1_doiCollection.banners,
+      size = ds5_v1_dois.size,
+      createdAt = ds5_v1_doiCollection.createdAt,
+      updatedAt = ds5_v1_doiCollection.updatedAt
+    )
+
     val result = ports.db
       .run(
         PublicDatasetVersionsMapper.getDatasetsByDoi(
@@ -971,7 +994,7 @@ class PublicDatasetVersionsMapperSpec
         collections = IndexedSeq.empty,
         externalPublications = IndexedSeq.empty,
         release = None,
-        doiCollection = Some(ds5_v1_doiCollection)
+        doiCollection = Some(ds5_v1_doiCollectionWithSize)
       )
 
     // Check Unpublished

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -402,6 +402,12 @@ class DatasetHandlerSpec
           banners = TestUtilities.randomBannerUrls
         )
 
+      val collectionDatasetV1DoiCollectionWithSize =
+        TestUtilities.addDoiCollectionDois(ports.db)(
+          collectionDatasetV1DoiCollection,
+          List(TestUtilities.randomString())
+        )
+
       val contributor = TestUtilities.createContributor(ports.db)(
         firstName = "Sally",
         lastName = "Fields",
@@ -452,7 +458,7 @@ class DatasetHandlerSpec
           )
         ),
         None,
-        Some(collectionDatasetV1DoiCollection)
+        Some(collectionDatasetV1DoiCollectionWithSize)
       )
 
       val responseWithAuth =
@@ -485,6 +491,12 @@ class DatasetHandlerSpec
           datasetId = collectionDatasetV1.datasetId,
           datasetVersion = collectionDatasetV1.version,
           banners = TestUtilities.randomBannerUrls
+        )
+
+      val collectionDatasetV1DoiCollectionWithSize =
+        TestUtilities.addDoiCollectionDois(ports.db)(
+          collectionDatasetV1DoiCollection,
+          List(TestUtilities.randomString())
         )
 
       val contributor = TestUtilities.createContributor(ports.db)(
@@ -532,7 +544,7 @@ class DatasetHandlerSpec
         Some(IndexedSeq.empty),
         None,
         None,
-        Some(collectionDatasetV1DoiCollection)
+        Some(collectionDatasetV1DoiCollectionWithSize)
       )
 
       val responseNoAuth =
@@ -634,6 +646,19 @@ class DatasetHandlerSpec
         banners = TestUtilities.randomBannerUrls
       )
 
+      val doiCollectionWithSize =
+        TestUtilities.addDoiCollectionDois(ports.db)(
+          doiCollection,
+          List(
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString()
+          )
+        )
+
       val response: GetDatasetByDoiResponse = datasetClient
         .getDatasetByDoi("10.12345", "abcd-efgh")
         .awaitFinite()
@@ -652,7 +677,7 @@ class DatasetHandlerSpec
               List.empty,
               None,
               None,
-              Some(doiCollection)
+              Some(doiCollectionWithSize)
             )
         )
       )
@@ -820,6 +845,12 @@ class DatasetHandlerSpec
           banners = TestUtilities.randomBannerUrls
         )
 
+      val ds5_v1_doiCollectionWithSize =
+        TestUtilities.addDoiCollectionDois(ports.db)(
+          ds5_v1_doiCollection,
+          List(TestUtilities.randomString(), TestUtilities.randomString())
+        )
+
       val ds1_v1_externalPub = TestUtilities.createExternalPublication(
         ports.db
       )(ds1_v1.datasetId, ds1_v1.version, References)
@@ -954,7 +985,7 @@ class DatasetHandlerSpec
               collections = IndexedSeq.empty,
               externalPublications = IndexedSeq.empty,
               datasetPreview = None,
-              doiCollection = Some(ds5_v1_doiCollection)
+              doiCollection = Some(ds5_v1_doiCollectionWithSize)
             )
           )
       }
@@ -1208,6 +1239,20 @@ class DatasetHandlerSpec
           datasetVersion = collectionDatasetV1.version,
           banners = TestUtilities.randomBannerUrls
         )
+      val collectionDatasetV1DoiCollectionWithSize =
+        TestUtilities.addDoiCollectionDois(ports.db)(
+          collectionDatasetV1DoiCollection,
+          List(
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString(),
+            TestUtilities.randomString()
+          )
+        )
 
       val dataset: PublicDataset = ports.db
         .run(
@@ -1226,7 +1271,7 @@ class DatasetHandlerSpec
         List.empty,
         None,
         None,
-        Some(collectionDatasetV1DoiCollection)
+        Some(collectionDatasetV1DoiCollectionWithSize)
       )
 
       val response =
@@ -1323,6 +1368,11 @@ class DatasetHandlerSpec
           datasetId = publicDataset4_V1.datasetId,
           datasetVersion = publicDataset4_V1.version,
           banners = TestUtilities.randomBannerUrls
+        )
+      val publicDataset4_V1_doiCollectionWithSize =
+        TestUtilities.addDoiCollectionDois(ports.db)(
+          publicDataset4_V1_doiCollection,
+          List(TestUtilities.randomString(), TestUtilities.randomString())
         )
 
       // Dataset 3 (embargoed)
@@ -1450,7 +1500,7 @@ class DatasetHandlerSpec
             Some(IndexedSeq.empty),
             None,
             None,
-            Some(publicDataset4_V1_doiCollection)
+            Some(publicDataset4_V1_doiCollectionWithSize)
           )
         ),
         toClientDefinition(

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -3561,9 +3561,7 @@ class DatasetHandlerSpec
 
       val limit = 3
 
-      // page 1
-      {
-        val offset = 0
+      def getAndCheckPage(offset: Int, expectedPageSize: Int): Unit = {
         val response = datasetClient
           .getDoiPage(
             datasetId = publishedCollectionVersion.datasetId,
@@ -3580,7 +3578,7 @@ class DatasetHandlerSpec
         response.offset shouldBe offset
         response.totalCount shouldBe datasetElements.size
 
-        response.dois.size shouldBe 3
+        response.dois.size shouldBe expectedPageSize
 
         response.dois
           .zip(datasetElements.slice(offset, limit + offset))
@@ -3596,136 +3594,21 @@ class DatasetHandlerSpec
               }
           }
       }
-
+      var offset = 0
+      //page 1
+      getAndCheckPage(offset, limit)
       //page 2
-      {
-        val offset = 3
-        val response = datasetClient
-          .getDoiPage(
-            datasetId = publishedCollectionVersion.datasetId,
-            versionId = publishedCollectionVersion.version,
-            offset = Some(offset),
-            limit = Some(limit)
-          )
-          .awaitFinite()
-          .value
-          .asInstanceOf[GetDoiPageResponse.OK]
-          .value
-
-        response.limit shouldBe limit
-        response.offset shouldBe offset
-        response.totalCount shouldBe datasetElements.size
-
-        response.dois.size shouldBe 3
-
-        response.dois
-          .zip(datasetElements.slice(offset, limit + offset))
-          .foreach {
-            case (doiInfo, (publicDataset, publicVersion)) =>
-              doiInfo.source shouldBe Pennsieve
-              inside(doiInfo.data) {
-                case FromPublicDTO(publicDTO) =>
-                  publicDTO.name shouldBe publicDataset.name
-                  publicDTO.id shouldBe publicDataset.id
-                  publicDTO.version shouldBe publicVersion.version
-                  publicDTO.doi shouldBe publicVersion.doi
-              }
-          }
-      }
-
-      //page 3
-      {
-        val offset = 6
-        val response = datasetClient
-          .getDoiPage(
-            datasetId = publishedCollectionVersion.datasetId,
-            versionId = publishedCollectionVersion.version,
-            offset = Some(offset),
-            limit = Some(limit)
-          )
-          .awaitFinite()
-          .value
-          .asInstanceOf[GetDoiPageResponse.OK]
-          .value
-
-        response.limit shouldBe limit
-        response.offset shouldBe offset
-        response.totalCount shouldBe datasetElements.size
-
-        response.dois.size shouldBe 3
-
-        response.dois
-          .zip(datasetElements.slice(offset, limit + offset))
-          .foreach {
-            case (doiInfo, (publicDataset, publicVersion)) =>
-              doiInfo.source shouldBe Pennsieve
-              inside(doiInfo.data) {
-                case FromPublicDTO(publicDTO) =>
-                  publicDTO.name shouldBe publicDataset.name
-                  publicDTO.id shouldBe publicDataset.id
-                  publicDTO.version shouldBe publicVersion.version
-                  publicDTO.doi shouldBe publicVersion.doi
-              }
-          }
-      }
-
-      //page 4
-      {
-        val offset = 9
-        val response = datasetClient
-          .getDoiPage(
-            datasetId = publishedCollectionVersion.datasetId,
-            versionId = publishedCollectionVersion.version,
-            offset = Some(offset),
-            limit = Some(limit)
-          )
-          .awaitFinite()
-          .value
-          .asInstanceOf[GetDoiPageResponse.OK]
-          .value
-
-        response.limit shouldBe limit
-        response.offset shouldBe offset
-        response.totalCount shouldBe datasetElements.size
-
-        response.dois.size shouldBe 1
-
-        response.dois
-          .zip(datasetElements.slice(offset, limit + offset))
-          .foreach {
-            case (doiInfo, (publicDataset, publicVersion)) =>
-              doiInfo.source shouldBe Pennsieve
-              inside(doiInfo.data) {
-                case FromPublicDTO(publicDTO) =>
-                  publicDTO.name shouldBe publicDataset.name
-                  publicDTO.id shouldBe publicDataset.id
-                  publicDTO.version shouldBe publicVersion.version
-                  publicDTO.doi shouldBe publicVersion.doi
-              }
-          }
-      }
-
-      // page 5 (empty)
-      {
-        val offset = 12
-        val response = datasetClient
-          .getDoiPage(
-            datasetId = publishedCollectionVersion.datasetId,
-            versionId = publishedCollectionVersion.version,
-            offset = Some(offset),
-            limit = Some(limit)
-          )
-          .awaitFinite()
-          .value
-          .asInstanceOf[GetDoiPageResponse.OK]
-          .value
-
-        response.limit shouldBe limit
-        response.offset shouldBe offset
-        response.totalCount shouldBe datasetElements.size
-
-        response.dois shouldBe empty
-      }
+      offset += limit
+      getAndCheckPage(offset, limit)
+      // page 3
+      offset += limit
+      getAndCheckPage(offset, limit)
+      // page 4
+      offset += limit
+      getAndCheckPage(offset, 1)
+      //page 5 empty
+      offset += limit
+      getAndCheckPage(offset, 0)
 
     }
 

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -3529,5 +3529,205 @@ class DatasetHandlerSpec
           externalDTO.doi shouldBe externalDoi
       }
     }
+
+    "page correctly" in {
+      val (_, publishedCollectionVersion) = setupForDoiCollectionTesting()
+
+      val datasetElements: IndexedSeq[(PublicDataset, PublicDatasetVersion)] =
+        for (i <- 0 until 10) yield {
+          val publishedDoi =
+            TestUtilities.randomPennsieveDoi(ports.config.doiCollections)
+
+          createDatasetAndVersion(
+            s"published $i",
+            i * 10,
+            publishedDoi,
+            PublishSucceeded
+          )
+        }
+
+      val dois: List[String] = datasetElements.map(_._2.doi).toList
+
+      ports.db
+        .run(
+          PublicDatasetDoiCollectionDoisMapper
+            .addDOIs(
+              publishedCollectionVersion.datasetId,
+              publishedCollectionVersion.version,
+              dois
+            )
+        )
+        .awaitFinite()
+
+      val limit = 3
+
+      // page 1
+      {
+        val offset = 0
+        val response = datasetClient
+          .getDoiPage(
+            datasetId = publishedCollectionVersion.datasetId,
+            versionId = publishedCollectionVersion.version,
+            offset = Some(offset),
+            limit = Some(limit)
+          )
+          .awaitFinite()
+          .value
+          .asInstanceOf[GetDoiPageResponse.OK]
+          .value
+
+        response.limit shouldBe limit
+        response.offset shouldBe offset
+        response.totalCount shouldBe datasetElements.size
+
+        response.dois.size shouldBe 3
+
+        response.dois
+          .zip(datasetElements.slice(offset, limit + offset))
+          .foreach {
+            case (doiInfo, (publicDataset, publicVersion)) =>
+              doiInfo.source shouldBe Pennsieve
+              inside(doiInfo.data) {
+                case FromPublicDTO(publicDTO) =>
+                  publicDTO.name shouldBe publicDataset.name
+                  publicDTO.id shouldBe publicDataset.id
+                  publicDTO.version shouldBe publicVersion.version
+                  publicDTO.doi shouldBe publicVersion.doi
+              }
+          }
+      }
+
+      //page 2
+      {
+        val offset = 3
+        val response = datasetClient
+          .getDoiPage(
+            datasetId = publishedCollectionVersion.datasetId,
+            versionId = publishedCollectionVersion.version,
+            offset = Some(offset),
+            limit = Some(limit)
+          )
+          .awaitFinite()
+          .value
+          .asInstanceOf[GetDoiPageResponse.OK]
+          .value
+
+        response.limit shouldBe limit
+        response.offset shouldBe offset
+        response.totalCount shouldBe datasetElements.size
+
+        response.dois.size shouldBe 3
+
+        response.dois
+          .zip(datasetElements.slice(offset, limit + offset))
+          .foreach {
+            case (doiInfo, (publicDataset, publicVersion)) =>
+              doiInfo.source shouldBe Pennsieve
+              inside(doiInfo.data) {
+                case FromPublicDTO(publicDTO) =>
+                  publicDTO.name shouldBe publicDataset.name
+                  publicDTO.id shouldBe publicDataset.id
+                  publicDTO.version shouldBe publicVersion.version
+                  publicDTO.doi shouldBe publicVersion.doi
+              }
+          }
+      }
+
+      //page 3
+      {
+        val offset = 6
+        val response = datasetClient
+          .getDoiPage(
+            datasetId = publishedCollectionVersion.datasetId,
+            versionId = publishedCollectionVersion.version,
+            offset = Some(offset),
+            limit = Some(limit)
+          )
+          .awaitFinite()
+          .value
+          .asInstanceOf[GetDoiPageResponse.OK]
+          .value
+
+        response.limit shouldBe limit
+        response.offset shouldBe offset
+        response.totalCount shouldBe datasetElements.size
+
+        response.dois.size shouldBe 3
+
+        response.dois
+          .zip(datasetElements.slice(offset, limit + offset))
+          .foreach {
+            case (doiInfo, (publicDataset, publicVersion)) =>
+              doiInfo.source shouldBe Pennsieve
+              inside(doiInfo.data) {
+                case FromPublicDTO(publicDTO) =>
+                  publicDTO.name shouldBe publicDataset.name
+                  publicDTO.id shouldBe publicDataset.id
+                  publicDTO.version shouldBe publicVersion.version
+                  publicDTO.doi shouldBe publicVersion.doi
+              }
+          }
+      }
+
+      //page 4
+      {
+        val offset = 9
+        val response = datasetClient
+          .getDoiPage(
+            datasetId = publishedCollectionVersion.datasetId,
+            versionId = publishedCollectionVersion.version,
+            offset = Some(offset),
+            limit = Some(limit)
+          )
+          .awaitFinite()
+          .value
+          .asInstanceOf[GetDoiPageResponse.OK]
+          .value
+
+        response.limit shouldBe limit
+        response.offset shouldBe offset
+        response.totalCount shouldBe datasetElements.size
+
+        response.dois.size shouldBe 1
+
+        response.dois
+          .zip(datasetElements.slice(offset, limit + offset))
+          .foreach {
+            case (doiInfo, (publicDataset, publicVersion)) =>
+              doiInfo.source shouldBe Pennsieve
+              inside(doiInfo.data) {
+                case FromPublicDTO(publicDTO) =>
+                  publicDTO.name shouldBe publicDataset.name
+                  publicDTO.id shouldBe publicDataset.id
+                  publicDTO.version shouldBe publicVersion.version
+                  publicDTO.doi shouldBe publicVersion.doi
+              }
+          }
+      }
+
+      // page 5 (empty)
+      {
+        val offset = 12
+        val response = datasetClient
+          .getDoiPage(
+            datasetId = publishedCollectionVersion.datasetId,
+            versionId = publishedCollectionVersion.version,
+            offset = Some(offset),
+            limit = Some(limit)
+          )
+          .awaitFinite()
+          .value
+          .asInstanceOf[GetDoiPageResponse.OK]
+          .value
+
+        response.limit shouldBe limit
+        response.offset shouldBe offset
+        response.totalCount shouldBe datasetElements.size
+
+        response.dois shouldBe empty
+      }
+
+    }
+
   }
 }


### PR DESCRIPTION
Three main changes in PR are

1. Include the number of DOIs in the `DOICollectionInfo` DTO so that these counts are available in the "get datasets" response.
2. Read and save the contributors list from the DOI Collection publish request.
3. Implement `GET /datasets/{datasetId}/versions/{versionId}/dois` to get detailed info about the datasets contained in a published collection.

For 3. I wanted to return an array of json objects that could either be a PublicDatasetDTO, TombstoneDTO, or some other object if the DOI was non-Pennsieve. This would require use of `oneOf` in the OpenAPI spec which our version of Guardrail does not support. 

I tried to upgrade the Guardrail version, but could not get it to run with the newest version. So instead, this PR uses `x-scala-type` to point Guardrail to a custom class. This class needs custom encoder and decoder code to avoid excessing nesting of intermediary classes only created to get around this Guardrail limitation.