### PR TITLE
Add publisherTag to WorkspaceSettings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   postgres:
     hostname: postgres
-    image: postgres:9.6
+    image: postgres:16.8
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres

--- a/server/src/main/resources/db/migration/V20250805134519__add_tag_to_workspace_settings.sql
+++ b/server/src/main/resources/db/migration/V20250805134519__add_tag_to_workspace_settings.sql
@@ -1,0 +1,9 @@
+ALTER TABLE workspace_settings
+    ADD COLUMN publisher_tag text;
+
+ALTER TABLE workspace_settings
+    DROP CONSTRAINT workspace_settings_organization_id_key;
+
+ALTER TABLE workspace_settings
+    ADD CONSTRAINT workspace_settings_organization_id_publisher_tag_key
+        UNIQUE NULLS NOT DISTINCT (organization_id, publisher_tag);

--- a/server/src/main/scala/com/pennsieve/discover/db/WorkspaceSettingsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/WorkspaceSettingsTable.scala
@@ -16,6 +16,7 @@ final class WorkspaceSettingsTable(tag: Tag)
   def publisherName = column[String]("publisher_name")
   def redirectUrl = column[String]("redirect_url")
   def redirectReleaseUrl = column[Option[String]]("redirect_release_url")
+  def publisherTag = column[Option[String]]("publisher_tag")
   def createdAt = column[OffsetDateTime]("created_at")
   def updatedAt = column[OffsetDateTime]("updated_at")
 
@@ -26,6 +27,7 @@ final class WorkspaceSettingsTable(tag: Tag)
       publisherName,
       redirectUrl,
       redirectReleaseUrl,
+      publisherTag,
       createdAt,
       updatedAt
     ).mapTo[WorkspaceSettings]
@@ -46,12 +48,19 @@ object WorkspaceSettingsMapper
     (this returning this) += settings
 
   def getSettings(
-    organizationId: Int
+    organizationId: Int,
+    publisherTag: Option[String] = None
   )(implicit
     executionContext: ExecutionContext
-  ): DBIOAction[Option[WorkspaceSettings], NoStream, Effect.Read with Effect] =
+  ): DBIOAction[Option[WorkspaceSettings], NoStream, Effect.Read with Effect] = {
     this
       .filter(_.organizationId === organizationId)
+      .filter { ws =>
+        publisherTag.fold(ws.publisherTag.isEmpty.?) { requestedTag =>
+          ws.publisherTag === requestedTag
+        }
+      }
       .result
       .headOption
+  }
 }

--- a/server/src/main/scala/com/pennsieve/discover/models/PublicDataset.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/PublicDataset.scala
@@ -27,6 +27,8 @@ object PublicDataset {
   implicit val encoder: Encoder[PublicDataset] = deriveEncoder[PublicDataset]
   implicit val decoder: Decoder[PublicDataset] = deriveDecoder[PublicDataset]
 
+  val publisherTagKey = "publisher"
+
   /*
    * This is required by slick when using a companion object on a case
    * class that defines a database table

--- a/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
+++ b/server/src/main/scala/com/pennsieve/discover/models/WorkspaceSettings.scala
@@ -25,6 +25,7 @@ case class WorkspaceSettings(
   publisherName: String,
   redirectUrl: String,
   redirectReleaseUrl: Option[String] = None,
+  publisherTag: Option[String] = None,
   createdAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
   updatedAt: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
 ) {

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -575,7 +575,11 @@ class SQSNotificationHandler(
     for {
       workspaceSettings <- ports.db.run(
         WorkspaceSettingsMapper
-          .getSettings(organizationId = publicDataset.sourceOrganizationId)
+          .getSettings(
+            organizationId = publicDataset.sourceOrganizationId,
+            publisherTag = publicDataset.tags
+              .find(_.startsWith(s"${PublicDataset.publisherTagKey}:"))
+          )
       )
 
       redirectSettings = workspaceSettings match {

--- a/server/src/test/scala/com/pennsieve/discover/DockerPostgresService.scala
+++ b/server/src/test/scala/com/pennsieve/discover/DockerPostgresService.scala
@@ -42,7 +42,7 @@ trait DockerPostgresService extends DockerKit {
     TestPostgresConfiguration.freshPostgresConfiguration
 
   val postgresContainer: DockerContainer =
-    DockerContainer("postgres:9.6")
+    DockerContainer("postgres:16.8")
       .withPorts(
         (
           TestPostgresConfiguration.advertisedPort,

--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -10,7 +10,8 @@ import com.pennsieve.discover.db.{
   PublicContributorsMapper,
   PublicDatasetVersionsMapper,
   PublicDatasetsMapper,
-  PublicFilesMapper
+  PublicFilesMapper,
+  WorkspaceSettingsMapper
 }
 import com.pennsieve.discover.notifications.SQSNotificationHandler
 import com.pennsieve.discover.models._
@@ -33,8 +34,8 @@ import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.regions.Region
 import squants.information.InformationConversions._
-import java.net.URI
 
+import java.net.URI
 import scala.concurrent.{ Await, ExecutionContext }
 import scala.concurrent.duration.{ DurationInt, FiniteDuration }
 
@@ -226,6 +227,7 @@ trait ServiceSpecHarness
         _ <- PublicDatasetsMapper.delete
         _ <- PublicDatasetVersionsMapper.delete
         _ <- PublicFilesMapper.delete
+        _ <- WorkspaceSettingsMapper.delete
       } yield ())
       .awaitFinite()
 

--- a/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
+++ b/server/src/test/scala/com/pennsieve/discover/TestUtilities.scala
@@ -568,6 +568,7 @@ object TestUtilities extends AwaitableImplicits {
   )(
     name: String = "My Dataset",
     sourceDatasetId: Int = 1,
+    tags: List[String] = List.empty,
     ownerId: Int = 1,
     ownerFirstName: String = "Fynn",
     ownerLastName: String = "Blackwell",
@@ -587,7 +588,7 @@ object TestUtilities extends AwaitableImplicits {
           ownerLastName = ownerLastName,
           ownerOrcid = ownerOrcid,
           license = license,
-          tags = List.empty,
+          tags = tags,
           datasetType = DatasetType.Collection
         )
       )

--- a/server/src/test/scala/com/pennsieve/discover/db/WorkspaceSettingsMapperSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/db/WorkspaceSettingsMapperSpec.scala
@@ -1,0 +1,138 @@
+// Copyright (c) 2019 Pennsieve, Inc. All Rights Reserved.
+
+package com.pennsieve.discover.db
+
+import com.pennsieve.discover.ServiceSpecHarness
+import com.pennsieve.discover.models.{ PublicDataset, WorkspaceSettings }
+import com.pennsieve.test.AwaitableImplicits
+import org.scalatest.Inside.inside
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class WorkspaceSettingsMapperSpec
+    extends AnyWordSpec
+    with ServiceSpecHarness
+    with AwaitableImplicits
+    with Matchers {
+
+  "WorkspaceSettingsTable" should {
+    "enforce nulls not distinct in lookup key" in {
+      val organizationId = 367
+      val organizationName = "SPARC"
+      val organizationRedirectUrlFormat =
+        "https://sparc.science/datasets/{{datasetId}}/version/{{versionId}}"
+      val organizationRedirectReleaseUrlFormat =
+        "https://sparc.science/code/{{datasetId}}/version/{{versionId}}"
+
+      val settings = WorkspaceSettings(
+        organizationId = organizationId,
+        publisherName = organizationName,
+        redirectUrl = organizationRedirectUrlFormat,
+        redirectReleaseUrl = Some(organizationRedirectReleaseUrlFormat)
+      )
+
+      // Add new settings
+      ports.db.run(WorkspaceSettingsMapper.addSettings(settings)).await
+
+      // second attempt to add settings with same org id should fail
+      val exception = intercept[org.postgresql.util.PSQLException] {
+        ports.db.run(WorkspaceSettingsMapper.addSettings(settings)).await
+      }
+
+      exception.getSQLState shouldBe "23505" // Unique violation in Postgres
+
+    }
+  }
+
+  "WorkspaceSettingsMapper" should {
+    "get None when no settings are defined" in {
+      val settings = ports.db.run(WorkspaceSettingsMapper.getSettings(1)).await
+
+      settings shouldBe None
+    }
+
+    "getSettings should return correct settings when no tag is present" in {
+      val organizationId = 367
+      val organizationName = "SPARC"
+      val organizationRedirectUrlFormat =
+        "https://sparc.science/datasets/{{datasetId}}/version/{{versionId}}"
+      val organizationRedirectReleaseUrlFormat =
+        "https://sparc.science/code/{{datasetId}}/version/{{versionId}}"
+
+      val settings = WorkspaceSettings(
+        organizationId = organizationId,
+        publisherName = organizationName,
+        redirectUrl = organizationRedirectUrlFormat,
+        redirectReleaseUrl = Some(organizationRedirectReleaseUrlFormat)
+      )
+
+      ports.db.run(WorkspaceSettingsMapper.addSettings(settings)).await
+
+      val settingsMaybe =
+        ports.db.run(WorkspaceSettingsMapper.getSettings(organizationId)).await
+
+      val actualSettings = settingsMaybe.value
+      actualSettings.organizationId shouldBe organizationId
+      actualSettings.publisherName shouldBe organizationName
+      actualSettings.redirectUrl shouldBe organizationRedirectUrlFormat
+      actualSettings.redirectReleaseUrl shouldBe Some(
+        organizationRedirectReleaseUrlFormat
+      )
+    }
+
+    "getSettings return correct settings when tag is present" in {
+      val organizationId = 676
+      val organizationName = "Publishing Collections"
+
+      val discoverSettings = WorkspaceSettings(
+        organizationId = organizationId,
+        publisherName = organizationName,
+        redirectUrl =
+          "https://discover.pennsieve.io/collections/{{datasetId}}/version/{{versionId}}"
+      )
+
+      val sparcSettings = WorkspaceSettings(
+        organizationId = organizationId,
+        publisherName = organizationName,
+        redirectUrl =
+          "https://sparc.science/collections/{{datasetId}}/version/{{versionId}}",
+        publisherTag = Some(s"${PublicDataset.publisherTagKey}:sparc")
+      )
+
+      ports.db
+        .run(
+          WorkspaceSettingsMapper
+            .addSettings(discoverSettings) >> WorkspaceSettingsMapper
+            .addSettings(sparcSettings)
+        )
+        .await
+
+      val actualDiscoverSettings = ports.db
+        .run(
+          WorkspaceSettingsMapper.getSettings(organizationId = organizationId)
+        )
+        .await
+        .value
+      actualDiscoverSettings.organizationId shouldBe organizationId
+      actualDiscoverSettings.publisherName shouldBe organizationName
+      actualDiscoverSettings.redirectUrl shouldBe discoverSettings.redirectUrl
+      actualDiscoverSettings.redirectReleaseUrl shouldBe None
+
+      val actualSparcSettings = ports.db
+        .run(
+          WorkspaceSettingsMapper.getSettings(
+            organizationId = organizationId,
+            publisherTag = sparcSettings.publisherTag
+          )
+        )
+        .await
+        .value
+
+      actualSparcSettings.organizationId shouldBe organizationId
+      actualSparcSettings.publisherName shouldBe organizationName
+      actualSparcSettings.redirectUrl shouldBe sparcSettings.redirectUrl
+      actualSparcSettings.redirectReleaseUrl shouldBe None
+    }
+
+  }
+}


### PR DESCRIPTION
When we map a URL to the DOI in DataCite for a published DOI collection we will want to be able to control which collections get mapped to `https://discover.pennsieve.io/collections/{datasetId}/version/{versionId}` and which are mapped to some other URL like `https://sparc.science/collections/{datasetId}/version/{versionId}`.

Currently this kind of mapping is determined by the source org id stored in the WorkspaceSettings table. But published DOI collections will all have the same source org, the special one we created to act as an id-space for the source dataset ids. So we need more information to determine the correct URL to map.

This PR adds a new nullable string column, `publisher_tag` to the WorkspaceSettings table, and creates a unique key on `(organzation_id, publisher_tag)` so that this pair can serve as a lookup key instead of `organization_id` alone.

Idea is that, given the Publishing Collections org id is 46, we will add rows such as
```
organization_id,  publisher_tag,  publisher_name,  redirect_url
46,  null,  Discover Collections,  https://discover.pennsieve.net/collections/{{datasetId}}/version/{{versionId}}
46,  publisher:sparc,  SPARC Collections,  https://sparc.science/collections/{{datasetId}}/version/{{versionId}}
46,  publisher:epilepsy,  Epilepsy.Science Collections,  https://epilepsy.science/collections/{{datasetId}}/version/{{versionId}} 
```
to the WorkspaceSettings table.

So if a published collection has a `publisher:` tag that is found in WorkspaceSettings, we used the mapped URL like sparc.science or epilepsy.science.

But if a published collection does not have a `publisher:` tag (or one that is not in WorkspaceSettings), then the mapped URL will be our default discover.pennsieve.{net,io} version.

PR includes the updates to SQSNotificationHandler to use the new column and tests.