### PR TITLE
Feature: permit asking for a specific release asset item by path and name

### DIFF
--- a/openapi/discover-service.yml
+++ b/openapi/discover-service.yml
@@ -679,6 +679,12 @@ paths:
             type: integer
             format: int32
             default: 0
+        - name: file
+          in: query
+          description: name of the file to find
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: successful operation

--- a/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseAssetsTable.scala
+++ b/server/src/main/scala/com/pennsieve/discover/db/PublicDatasetReleaseAssetsTable.scala
@@ -191,6 +191,7 @@ object PublicDatasetReleaseAssetMapper
   def childrenOf(
     version: PublicDatasetVersion,
     path: Option[String],
+    name: Option[String] = None,
     limit: Int = 100,
     offset: Int = 0
   )(implicit
@@ -209,6 +210,11 @@ object PublicDatasetReleaseAssetMapper
       case None => "*{1}"
     }
 
+    val nameSelector = name match {
+      case Some(name) => name
+      case None => "%"
+    }
+
     val datasetId = version.datasetId
     val datasetVersion = version.version
 
@@ -223,6 +229,7 @@ object PublicDatasetReleaseAssetMapper
           WHERE dataset_id = $datasetId
           AND dataset_version = $datasetVersion
           AND path ~ $leafChildSelector::lquery
+          AND name LIKE $nameSelector
         ),
         total_count as (
           select null::text AS type,

--- a/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/DatasetHandler.scala
@@ -927,7 +927,8 @@ class DatasetHandler(
     versionId: Int,
     path: Option[String],
     limit: Option[Int],
-    offset: Option[Int]
+    offset: Option[Int],
+    file: Option[String]
   ): Future[GuardrailResource.BrowseAssetsResponse] = {
     def valid(path: Option[String]): Option[String] =
       path match {
@@ -951,6 +952,7 @@ class DatasetHandler(
         .childrenOf(
           version,
           valid(path),
+          name = file,
           limit = limit.getOrElse(defaultFileLimit),
           offset = offset.getOrElse(defaultFileOffset)
         )

--- a/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/DatasetHandlerSpec.scala
@@ -3202,13 +3202,15 @@ class DatasetHandlerSpec
   }
 
   def setupForReleaseAssetTesting(
+    sourceOrganizationId: Int = 1,
+    sourceDatasetId: Int = 333
   ): (PublicDataset, PublicDatasetVersion, ReleaseAssetListing) = {
     // create dataset
     val dataset = TestUtilities.createDataset(ports.db)(
       name = "filtered dataset 1",
       datasetType = DatasetType.Release,
-      sourceOrganizationId = 1,
-      sourceDatasetId = 333
+      sourceOrganizationId = sourceOrganizationId,
+      sourceDatasetId = sourceDatasetId
     )
 
     // create version
@@ -3362,6 +3364,30 @@ class DatasetHandlerSpec
         .value
 
       response.assets.length shouldEqual 1
+    }
+
+    "return specific asset when requested" in {
+      val (dataset, version, listing) = setupForReleaseAssetTesting()
+
+      val assetPath = "data"
+      val assetName = "subjects.csv"
+
+      val response = datasetClient
+        .browseAssets(
+          dataset.id,
+          version.version,
+          path = Some(assetPath),
+          file = Some(assetName)
+        )
+        .awaitFinite()
+        .value
+        .asInstanceOf[BrowseAssetsResponse.OK]
+        .value
+
+      response.assets.length shouldEqual 1
+
+      val asset = response.assets.head
+      asset.name shouldBe assetName
     }
 
     "return nothing when path does not exist" in {
@@ -3613,4 +3639,5 @@ class DatasetHandlerSpec
     }
 
   }
+
 }


### PR DESCRIPTION
Expand the _Browse Release Assets_ API Endpoint to permit asking for a specific file in the release asset (Zip file).

Adds the optional `?file` query parameter. When present, the browse will attempt to find the file in the specified folder path (value of `?path` query parameter).

Note: this will greatly help **SPARC SIM-Core** when processing a Code Repo release, and looking to see if specific files were included in the GitHub release. 