### PR TITLE
Update AthenaClient to query SPARC AWS Open Data S3 access logs.

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -145,6 +145,9 @@ athena {
     rejoin-bucket-access-table = "rejoin_glue_catalog.dev_s3_access_logs_db.discover"
     rejoin-bucket-access-table = ${?REJOIN_BUCKET_ACCESS_GLUE_TABLE}
 
+    sparc-aod-bucket-access-table = "sparc_aod_glue_catalog.dev_s3_access_logs_db.discover"
+    sparc-aod-bucket-access-table = ${?SPARC_AOD_BUCKET_ACCESS_GLUE_TABLE}
+
   default {
     driver = "com.simba.athena.jdbc.Driver"
     driver = ${?ATHENA_DRIVER}

--- a/server/src/main/scala/com/pennsieve/discover/Config.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Config.scala
@@ -126,7 +126,8 @@ case class ExternalPublishBucketConfiguration(bucket: S3Bucket, roleArn: Arn)
 case class AthenaConfig(
   pennsieveBucketAccessTable: String,
   sparcBucketAccessTable: String,
-  rejoinBucketAccessTable: String
+  rejoinBucketAccessTable: String,
+  sparcAodBucketAccessTable: String
 )
 
 case class RuntimeSettings(deleteReleaseIntermediateFile: Boolean)

--- a/server/src/main/scala/com/pennsieve/discover/Ports.scala
+++ b/server/src/main/scala/com/pennsieve/discover/Ports.scala
@@ -146,7 +146,8 @@ object Ports {
     val athenaClient: AthenaClient = new AthenaClientImpl(
       pennsieveTable = config.athena.pennsieveBucketAccessTable,
       sparcTable = config.athena.sparcBucketAccessTable,
-      rejoinTable = config.athena.rejoinBucketAccessTable
+      rejoinTable = config.athena.rejoinBucketAccessTable,
+      sparcAodTable = config.athena.sparcAodBucketAccessTable
     )
 
     Ports(

--- a/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/AthenaClient.scala
@@ -21,7 +21,8 @@ trait AthenaClient {
 class AthenaClientImpl(
   val pennsieveTable: String,
   val sparcTable: String,
-  val rejoinTable: String
+  val rejoinTable: String,
+  val sparcAodTable: String
 ) extends AthenaClient {
 
   def getDatasetDownloadsForRange(
@@ -38,6 +39,8 @@ class AthenaClientImpl(
             | ${tableQuery(sparcTable, startDate, endDate)}
             | UNION
             | ${tableQuery(rejoinTable, startDate, endDate)}
+            | UNION
+            | ${tableQuery(sparcAodTable, startDate, endDate)}
             | ORDER BY  dataset_id, version, dl_date;""".stripMargin
         .map(
           rs =>

--- a/server/src/test/resources/config-with-external-buckets.conf
+++ b/server/src/test/resources/config-with-external-buckets.conf
@@ -139,6 +139,7 @@ athena {
     pennsieve-bucket-access-table = "s3_access_logs_db.discover"
     sparc-bucket-access-table = "sparc_dev_catalog.dev_discover_s3_access_logs_db.discover_logs"
     rejoin-bucket-access-table = "rejoin_dev_catalog.dev_discover_s3_access_logs_db.discover_logs"
+    sparc-aod-bucket-access-table = "sparc_aod_glue_catalog.dev_s3_access_logs_db.discover"
 
   default {
     driver = "com.simba.athena.jdbc.Driver"

--- a/server/src/test/resources/config-without-external-buckets.conf
+++ b/server/src/test/resources/config-without-external-buckets.conf
@@ -139,6 +139,8 @@ athena {
     pennsieve-bucket-access-table = "s3_access_logs_db.discover"
     sparc-bucket-access-table = "sparc_dev_catalog.dev_discover_s3_access_logs_db.discover_logs"
     rejoin-bucket-access-table = "rejoin_dev_catalog.dev_discover_s3_access_logs_db.discover_logs"
+    sparc-aod-bucket-access-table = "sparc_aod_glue_catalog.dev_s3_access_logs_db.discover"
+
 
   default {
     driver = "com.simba.athena.jdbc.Driver"

--- a/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
+++ b/server/src/test/scala/com/pennsieve/discover/ServiceSpecHarness.scala
@@ -115,7 +115,9 @@ trait ServiceSpecHarness
         sparcBucketAccessTable =
           "sparc_glue_catalog.dev_s3_access_logs_db.discover",
         rejoinBucketAccessTable =
-          "rejoin_glue_catalog.dev_s3_access_logs_db.discover"
+          "rejoin_glue_catalog.dev_s3_access_logs_db.discover",
+        sparcAodBucketAccessTable =
+          "sparc_aod_glue_catalog.dev_s3_access_logs_db.discover"
       ),
       runtimeSettings = RuntimeSettings(deleteReleaseIntermediateFile = false),
       doiCollections = DoiCollections(

--- a/server/src/test/scala/com/pennsieve/discover/integration/AthenaClientIntegrationSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/integration/AthenaClientIntegrationSpec.scala
@@ -31,7 +31,8 @@ class AthenaClientIntegrationSpec
       val athenaClient: AthenaClient = new AthenaClientImpl(
         pennsieveTable = config.athena.pennsieveBucketAccessTable,
         sparcTable = config.athena.sparcBucketAccessTable,
-        rejoinTable = config.athena.rejoinBucketAccessTable
+        rejoinTable = config.athena.rejoinBucketAccessTable,
+        sparcAodTable = config.athena.sparcAodBucketAccessTable
       )
 
       val athenaDownloads = athenaClient.getDatasetDownloadsForRange(

--- a/terraform/athena.tf
+++ b/terraform/athena.tf
@@ -22,4 +22,14 @@ resource "aws_athena_data_catalog" "rejoin_glue_catalog" {
     "catalog-id" = data.terraform_remote_state.platform_infrastructure.outputs.rejoin_account_id
   }
 }
+
+resource "aws_athena_data_catalog" "sparc_aod_glue_catalog" {
+  name        = var.sparc_aod_glue_catalog
+  description = "SPARC AOD's Glue based Data Catalog"
+  type        = "GLUE"
+
+  parameters = {
+    "catalog-id" = var.sparc_aod_account_number
+  }
+}
   

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -276,7 +276,8 @@ data "aws_iam_policy_document" "iam_policy_document" {
     actions = ["athena:GetDataCatalog"]
     resources = [
       "arn:aws:athena:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:datacatalog/${aws_athena_data_catalog.sparc_glue_catalog.name}",
-      "arn:aws:athena:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:datacatalog/${aws_athena_data_catalog.rejoin_glue_catalog.name}"
+      "arn:aws:athena:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:datacatalog/${aws_athena_data_catalog.rejoin_glue_catalog.name}",
+      "arn:aws:athena:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:datacatalog/${aws_athena_data_catalog.sparc_aod_glue_catalog.name}"
     ]
   }
 

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -340,6 +340,12 @@ resource "aws_ssm_parameter" "rejoin_bucket_access_glue_table" {
   value = "${var.rejoin_glue_catalog}.${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_glue_db}.${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_glue_table}"
 }
 
+resource "aws_ssm_parameter" "sparc_aod_bucket_access_glue_table" {
+  name  = "/${var.environment_name}/${var.service_name}/sparc-aod-bucket-access-glue-table"
+  type  = "String"
+  value = "${var.sparc_aod_glue_catalog}.${local.sparc_aod_glue_db_table}"
+}
+
 // SNS CONFIGURATION
 
 # resource "aws_ssm_parameter" "sns_alert_topic" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,6 +39,10 @@ variable "rejoin_glue_catalog" {
   default = "rejoin_glue_catalog"
 }
 
+variable "sparc_aod_glue_catalog" {
+  default = "sparc_aod_glue_catalog"
+}
+
 // doi_collections_id_space_id is the id of the workspace that acts
 // as the id-space for published collections
 variable "doi_collections_id_space_id" {}
@@ -46,6 +50,10 @@ variable "doi_collections_id_space_id" {}
 // doi_collections_id_space_name is the name of the workspace that acts
 // as the id-space for published collections
 variable "doi_collections_id_space_name" {}
+
+
+// AWS Account number for SPARC AOD
+variable "sparc_aod_account_number" {}
 
 locals {
   java_opts = [
@@ -71,5 +79,7 @@ locals {
   sparc_environment_name = var.environment_name == "dev" ? "dev" : "prd"
 
   pennsieve_doi_prefix = var.environment_name == "prod" ? "10.26275" : "10.21397"
+
+  sparc_aod_glue_db_table = "${var.environment_name}_s3_access_logs_db.discover"
 
 }


### PR DESCRIPTION
PR updates Terraform and config to include the Athena table in the SPARC AWS Open Data account that will hold its S3 access logs and the permissions required to query it. Associated infrastructure PR is https://github.com/Pennsieve/infrastructure/pull/332.

Also updates the Athena client to add this table to its union query that is used to get the download metrics for direct S3 downloads.

