### PR TITLE
FIX: missing Glue and S3 permissions for SPARC AOD metrics

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -249,12 +249,18 @@ data "aws_iam_policy_document" "iam_policy_document" {
     effect = "Allow"
     actions = ["glue:*"]
     resources = [
+      // SPARC
       "arn:aws:glue:${data.aws_region.current_region.name}:${data.terraform_remote_state.platform_infrastructure.outputs.sparc_account_id}:catalog",
       "arn:aws:glue:${data.aws_region.current_region.name}:${data.terraform_remote_state.platform_infrastructure.outputs.sparc_account_id}:database/${data.terraform_remote_state.platform_infrastructure.outputs.sparc_s3_access_logs_glue_db}",
       "arn:aws:glue:${data.aws_region.current_region.name}:${data.terraform_remote_state.platform_infrastructure.outputs.sparc_account_id}:table/${data.terraform_remote_state.platform_infrastructure.outputs.sparc_s3_access_logs_glue_db}/${data.terraform_remote_state.platform_infrastructure.outputs.sparc_s3_access_logs_glue_table}",
+      // REJOIN and Precision
       "arn:aws:glue:${data.aws_region.current_region.name}:${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_account_id}:catalog",
       "arn:aws:glue:${data.aws_region.current_region.name}:${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_account_id}:database/${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_glue_db}",
-      "arn:aws:glue:${data.aws_region.current_region.name}:${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_account_id}:table/${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_glue_db}/${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_glue_table}"
+      "arn:aws:glue:${data.aws_region.current_region.name}:${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_account_id}:table/${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_glue_db}/${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_glue_table}",
+      // SPARC AOD
+      "arn:aws:glue:${data.aws_region.current_region.name}:${var.sparc_aod_account_number}:catalog",
+      "arn:aws:glue:${data.aws_region.current_region.name}:${var.sparc_aod_account_number}:database/${local.sparc_aod.glue_db}",
+      "arn:aws:glue:${data.aws_region.current_region.name}:${var.sparc_aod_account_number}:table/${local.sparc_aod.glue_db}/${local.sparc_aod.glue_table}"
     ]
   }
 
@@ -263,10 +269,15 @@ data "aws_iam_policy_document" "iam_policy_document" {
     effect = "Allow"
     actions = ["s3:*"]
     resources = [
+      // SPARC
       "arn:aws:s3:::${data.terraform_remote_state.platform_infrastructure.outputs.sparc_s3_access_logs_bucket}",
       "arn:aws:s3:::${data.terraform_remote_state.platform_infrastructure.outputs.sparc_s3_access_logs_bucket}/${data.terraform_remote_state.platform_infrastructure.outputs.sparc_s3_access_logs_prefix}*",
+      // REJOIN and Precision
       "arn:aws:s3:::${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_bucket}",
-      "arn:aws:s3:::${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_bucket}/${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_prefix}*"
+      "arn:aws:s3:::${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_bucket}/${data.terraform_remote_state.platform_infrastructure.outputs.rejoin_s3_access_logs_prefix}*",
+      // SPARC AOD
+      "arn:aws:s3:::${local.sparc_aod.s3_access_logs_bucket}",
+      "arn:aws:s3:::${local.sparc_aod.s3_access_logs_bucket}/${local.sparc_aod.s3_access_logs_prefix}*"
     ]
   }
 

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -343,7 +343,7 @@ resource "aws_ssm_parameter" "rejoin_bucket_access_glue_table" {
 resource "aws_ssm_parameter" "sparc_aod_bucket_access_glue_table" {
   name  = "/${var.environment_name}/${var.service_name}/sparc-aod-bucket-access-glue-table"
   type  = "String"
-  value = "${var.sparc_aod_glue_catalog}.${local.sparc_aod_glue_db_table}"
+  value = "${var.sparc_aod_glue_catalog}.${local.sparc_aod.glue_db}.${local.sparc_aod.glue_table}"
 }
 
 // SNS CONFIGURATION

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -80,6 +80,14 @@ locals {
 
   pennsieve_doi_prefix = var.environment_name == "prod" ? "10.26275" : "10.21397"
 
-  sparc_aod_glue_db_table = "${var.environment_name}_s3_access_logs_db.discover"
+  // No remote Terraform state for SPARC AOD to draw from
+  // These are the names inside the AOD account relevant to Glue and Athena
+  // for S3 access logging
+  sparc_aod = {
+    glue_db = "${var.environment_name}_s3_access_logs_db"
+    glue_table = "discover"
+    s3_access_logs_bucket = "sparc-${var.environment_name}-aod-s3-access-logs"
+    s3_access_logs_prefix = "${var.environment_name}/discover-publish/"
+  }
 
 }


### PR DESCRIPTION
Fixes #133 to include necessary permissions that are missing. 

These permissions are necessary for the endpoint `/discover/metrics/dataset/athena/download/sync` to work with the newly added SPARC AOD Athena table.