### PR TITLE
Pass Publish Type to Sync Task

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/clients/ECSClient.scala
+++ b/server/src/main/scala/com/pennsieve/discover/clients/ECSClient.scala
@@ -4,6 +4,7 @@ package com.pennsieve.discover.clients
 
 import com.pennsieve.discover.StorageCleanupTaskConfiguration
 import com.pennsieve.discover.models.DatasetMetadata
+import com.pennsieve.discover.notifications.SQSNotificationType
 import com.pennsieve.models.PublishStatus
 import com.typesafe.scalalogging.StrictLogging
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
@@ -40,6 +41,7 @@ trait ECSClient {
     * @param lastPublishedDate The timestamp when the version was published
     * @param organizationId The source organization ID
     * @param publishStatus The publish status (e.g., PublishSucceeded, EmbargoSucceeded)
+    * @param publishType The type of publish operation (PUBLISH or RELEASE)
     * @param s3Bucket The S3 bucket where the dataset is published
     * @param s3Key The S3 key prefix for the published dataset
     * @return The RunTaskResponse from ECS
@@ -51,6 +53,7 @@ trait ECSClient {
     lastPublishedDate: OffsetDateTime,
     organizationId: Int,
     publishStatus: PublishStatus,
+    publishType: SQSNotificationType,
     s3Bucket: String,
     s3Key: String
   )(implicit
@@ -76,6 +79,7 @@ class AwsECSClient(config: StorageCleanupTaskConfiguration, region: Region)
     lastPublishedDate: OffsetDateTime,
     organizationId: Int,
     publishStatus: PublishStatus,
+    publishType: SQSNotificationType,
     s3Bucket: String,
     s3Key: String
   )(implicit
@@ -112,6 +116,11 @@ class AwsECSClient(config: StorageCleanupTaskConfiguration, region: Region)
         .builder()
         .name("PUBLISH_STATUS")
         .value(publishStatus.entryName)
+        .build(),
+      KeyValuePair
+        .builder()
+        .name("PUBLISH_TYPE")
+        .value(publishType.entryName)
         .build(),
       KeyValuePair.builder().name("PUBLISHED_BUCKET").value(s3Bucket).build(),
       KeyValuePair.builder().name("PUBLISHED_S3_PREFIX").value(s3Key).build(),

--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -415,7 +415,12 @@ class SQSNotificationHandler(
         ports.log.info(
           "handleSuccess() non-embargo publish - invoking storage sync task"
         )
-        invokeStorageSyncTask(publicDataset, updatedVersion, publishStatus)
+        invokeStorageSyncTask(
+          publicDataset,
+          updatedVersion,
+          publishStatus,
+          SQSNotificationType.PUBLISH
+        )
       }
 
       // invoke S3 Cleanup Lambda to delete publishing intermediate files
@@ -521,7 +526,8 @@ class SQSNotificationHandler(
   private def invokeStorageSyncTask(
     publicDataset: PublicDataset,
     version: PublicDatasetVersion,
-    publishStatus: DatasetPublishStatus
+    publishStatus: DatasetPublishStatus,
+    publishType: SQSNotificationType
   )(implicit
     logContext: LogContext
   ): Future[Unit] =
@@ -533,7 +539,7 @@ class SQSNotificationHandler(
 
       _ <- if (s3StorageCleanupTaskEnabled) {
         ports.log.info(
-          s"invokeStorageSyncTask() s3StorageCleanupTaskEnabled=true, invoking s3 storage cleanup task with status=${publishStatus.status}"
+          s"invokeStorageSyncTask() s3StorageCleanupTaskEnabled=true, invoking s3 storage cleanup task with status=${publishStatus.status} publishType=$publishType"
         )
         ports.ecsClient.runS3StorageCleanupTask(
           sourceDatasetId = publicDataset.sourceDatasetId,
@@ -542,6 +548,7 @@ class SQSNotificationHandler(
           lastPublishedDate = version.createdAt,
           organizationId = publicDataset.sourceOrganizationId,
           publishStatus = publishStatus.status,
+          publishType = publishType,
           s3Bucket = version.s3Bucket.value,
           s3Key = version.s3Key.value
         )
@@ -586,7 +593,12 @@ class SQSNotificationHandler(
       }
 
       _ = ports.log.info("handleReleaseSuccess() invoking storage sync task")
-      _ <- invokeStorageSyncTask(publicDataset, updatedVersion, publishStatus)
+      _ <- invokeStorageSyncTask(
+        publicDataset,
+        updatedVersion,
+        publishStatus,
+        SQSNotificationType.RELEASE
+      )
 
       // Add dataset to search index
       _ <- Search.indexDataset(publicDataset, updatedVersion, ports)

--- a/server/src/test/scala/com/pennsieve/discover/clients/MockECSClient.scala
+++ b/server/src/test/scala/com/pennsieve/discover/clients/MockECSClient.scala
@@ -2,6 +2,7 @@
 
 package com.pennsieve.discover.clients
 
+import com.pennsieve.discover.notifications.SQSNotificationType
 import com.pennsieve.models.PublishStatus
 import software.amazon.awssdk.services.ecs.model.{ RunTaskResponse, Task }
 
@@ -16,6 +17,7 @@ case class S3StorageCleanupTaskRequest(
   lastPublishedDate: OffsetDateTime,
   organizationId: Int,
   publishStatus: PublishStatus,
+  publishType: SQSNotificationType,
   s3Bucket: String,
   s3Key: String
 )
@@ -35,6 +37,7 @@ class MockECSClient extends ECSClient {
     lastPublishedDate: OffsetDateTime,
     organizationId: Int,
     publishStatus: PublishStatus,
+    publishType: SQSNotificationType,
     s3Bucket: String,
     s3Key: String
   )(implicit
@@ -47,6 +50,7 @@ class MockECSClient extends ECSClient {
       lastPublishedDate,
       organizationId,
       publishStatus,
+      publishType,
       s3Bucket,
       s3Key
     )


### PR DESCRIPTION
## Motivation
The publish-storage-sync task uses the publish type to send the correct failure status to the API `publish/complete` endpoint: https://github.com/Pennsieve/publish-storage-sync/pull/8

Pass either `PUBLISH` or `RELEASE` from the `SQSNotificationType` to help it distinguish between the two.