### PR TITLE
no storage sync after embargo release

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/notifications/SQSNotificationHandler.scala
@@ -592,13 +592,10 @@ class SQSNotificationHandler(
           Future.successful(true)
       }
 
-      _ = ports.log.info("handleReleaseSuccess() invoking storage sync task")
-      _ <- invokeStorageSyncTask(
-        publicDataset,
-        updatedVersion,
-        publishStatus,
-        SQSNotificationType.RELEASE
-      )
+      _ <- ports.pennsieveApiClient
+        .putPublishComplete(publishStatus, None)
+        .value
+        .flatMap(_.fold(Future.failed, Future.successful))
 
       // Add dataset to search index
       _ <- Search.indexDataset(publicDataset, updatedVersion, ports)


### PR DESCRIPTION
PR removes the call to start the publish-storage-sync task after a successful embargo release and replaces it with the call to Pennsieve API to notify it of the release.

This is a temporary measure until a bug with embargoed datasets' manifest file is resolved.