### PR TITLE
Index public_file_versions.source_package_id

### DIFF
--- a/server/src/main/resources/db/migration/V20260421160218__index_public_file_versions_source_package_id.sql
+++ b/server/src/main/resources/db/migration/V20260421160218__index_public_file_versions_source_package_id.sql
@@ -1,0 +1,25 @@
+/*
+** Add an index on public_file_versions.source_package_id.
+**
+** Why: the GET /packages/{sourcePackageId}/files endpoint
+** (FileHandler.getFileFromSourcePackageId, backed by
+** PublicFileVersionsTable.getFileFromSourcePackageId) filters a
+** 4-way join on source_package_id. That column has had no index
+** since the table was introduced in V20230704074854, so every call
+** does a sequential scan. Observed response time: ~13s on prod.
+**
+** Partial on IS NOT NULL: source_package_id is nullable and many
+** historical rows have NULL. The lookup predicate "= 'N:package:...'"
+** can never match NULL, so excluding NULL rows keeps the index small
+** and cheap to maintain. Postgres proves the implication and will
+** still use the index for the lookup.
+**
+** Non-concurrent: Flyway 4.x wraps migrations in a transaction and
+** CREATE INDEX CONCURRENTLY cannot run in a transaction. Takes an
+** AccessExclusiveLock during build, briefly blocking writes. Writes
+** to public_file_versions happen only during dataset publishing —
+** acceptable transient blockage.
+*/
+CREATE INDEX IF NOT EXISTS public_file_versions_source_package_id_idx
+    ON public_file_versions (source_package_id)
+    WHERE source_package_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Adds an index on `public_file_versions.source_package_id` to fix a 13s sequential scan on `GET /discover/packages/{sourcePackageId}/files`.

## The problem

`FileHandler.getFileFromSourcePackageId` (server/src/main/scala/com/pennsieve/discover/handlers/FileHandler.scala:38) calls `PublicFileVersionsTable.getFileFromSourcePackageId` (db/PublicFileVersionsTable.scala:268), which runs a 4-way join filtered on `source_package_id`:

```scala
this
  .join(PublicDatasetVersionFilesTableMapper)
  .join(latestDatasetVersions)
  .join(PublicDatasetsMapper)
  .on { ... }
  .filter(_._1._1._1.sourcePackageId === sourcePackageId)
```

The `source_package_id` column has **no index** (verified against all `CREATE INDEX` statements in `server/src/main/resources/db/migration/`). The table was introduced in V20230704074854 without one. As the table has grown, every call to this endpoint does a full seq scan. Measured response time on prod: ~13s.

## The fix

```sql
CREATE INDEX IF NOT EXISTS public_file_versions_source_package_id_idx
    ON public_file_versions (source_package_id)
    WHERE source_package_id IS NOT NULL;
```

**Partial index** on `IS NOT NULL` because:
- `source_package_id` is nullable; many historical rows have NULL
- The lookup predicate `= 'N:package:...'` never matches NULL
- Postgres can prove the implication and will still use the partial index for the equality lookup
- Keeps the index smaller and cheaper to maintain

**Plain (non-concurrent) CREATE INDEX** because Flyway 4.2.0 (pulled in transitively via `service-utilities`) wraps every migration in a transaction and `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. Takes an `AccessExclusiveLock` during index build, briefly blocking writes on `public_file_versions`. Writes to this table happen only during dataset publishing (infrequent, manual) — acceptable transient blockage. The existing `public_files_path_idx` (V20190717153448) uses plain `CREATE INDEX` for the same reason.

## Expected impact

13s → <100ms for this endpoint. Seq scan becomes an index lookup.

## Validation

Anyone with prod access can confirm post-deploy with:

```sql
EXPLAIN (ANALYZE, BUFFERS)
SELECT count(*)
FROM public_file_versions fv
JOIN public_dataset_version_files dvf ON dvf.file_id = fv.id
WHERE fv.source_package_id = 'N:package:60ba57c1-831d-4e2f-bd22-b53de369d82a';
```

Look for `Index Scan using public_file_versions_source_package_id_idx` instead of `Seq Scan on public_file_versions`.

## What this PR doesn't do (follow-ups)

Three further improvements scoped for this endpoint, not in this PR:

1. **Skip the "fetch every matching row just to grab the org id" subquery** — `PublicFileVersionsTable.scala:301-304` fetches all matching rows' `source_organization_id` and then `.headOption`s one out. Adding `.take(1)` before `.result` makes it `LIMIT 1`. 1-line fix.
2. **Collapse the three sequential DB round-trips into one** — the handler runs count + org-id + paginated-page as three separate queries, each re-executing the full join. A single query with `count(*) OVER ()` gives all three in one round-trip. Medium refactor; easier as raw SQL than in Slick.
3. **Cache-Control headers for the response** — files of a published package version are immutable; a 24h CDN cache eliminates repeat DB hits entirely for browser-driven traffic.

Happy to open those as separate PRs once this one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)