### PR TITLE
Bug/re publish bucket fix

### DIFF
--- a/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
+++ b/server/src/main/scala/com/pennsieve/discover/handlers/PublishHandler.scala
@@ -237,10 +237,13 @@ class PublishHandler(
               case _ => requestedWorkflow
             }
 
-            // ensure we use the same S3 Bucket as previous published versions
+            // ensure we use the same S3 Bucket as previous published versions,
+            // but honor the current bucket config when the last version was
+            // unpublished (otherwise a republish stays pinned to the old bucket)
             destinationS3Bucket = latest match {
-              case Some(version) => version.s3Bucket
-              case None => targetS3Bucket
+              case Some(version) if version.status != Unpublished =>
+                version.s3Bucket
+              case _ => targetS3Bucket
             }
 
             version <- PublicDatasetVersionsMapper

--- a/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
+++ b/server/src/test/scala/com/pennsieve/discover/handlers/PublishHandlerSpec.scala
@@ -2861,6 +2861,117 @@ class PublishHandlerSpec
       publicVersion2.s3Bucket shouldBe S3Bucket(publishBucket)
     }
 
+    "use the org's current bucket when republishing after an unpublish" in {
+      // Regression test: a dataset first published to an old/default bucket and
+      // then unpublished must NOT stay pinned to that bucket on republish. The
+      // latest visible version is now Unpublished, so the publish handler should
+      // fall back to the bucket config supplied with the new publish request.
+      val oldPublishBucket = s"old-publish-bucket-${organizationId}"
+      val oldEmbargoBucket = s"old-embargo-bucket-${organizationId}"
+      val oldBucketConfig = definitions.BucketConfig(
+        publish = oldPublishBucket,
+        embargo = oldEmbargoBucket
+      )
+
+      val datasetName = "republished after unpublish into a new bucket"
+
+      val requestBody1: definitions.PublishRequest = definitions.PublishRequest(
+        name = datasetName,
+        description = "A very very long description...",
+        ownerId = 1,
+        modelCount = Vector(definitions.ModelCount("myConcept", 100L)),
+        recordCount = 100L,
+        fileCount = 100L,
+        size = 5555555L,
+        license = License.`Apache 2.0`,
+        contributors = Vector(internalContributor),
+        externalPublications = Some(Vector(internalExternalPublication)),
+        tags = Vector[String]("tag1", "tag2"),
+        ownerNodeId = ownerNodeId,
+        ownerFirstName = ownerFirstName,
+        ownerLastName = ownerLastName,
+        ownerOrcid = ownerOrcid,
+        organizationNodeId = organizationNodeId,
+        organizationName = organizationName,
+        datasetNodeId = datasetNodeId,
+        bucketConfig = Some(oldBucketConfig),
+        workflowId = Some(5)
+      )
+
+      // publish v1 into the OLD bucket, complete it, then unpublish it
+      val _ = client
+        .publish(organizationId, datasetId, None, None, requestBody1, authToken)
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishResponse.Created]
+        .value
+
+      val publicDataset = ports.db
+        .run(
+          PublicDatasetsMapper
+            .getDatasetFromSourceIds(organizationId, datasetId)
+        )
+        .awaitFinite()
+
+      val publicVersion1 = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getLatestVersion(publicDataset.id)
+        )
+        .awaitFinite()
+        .get
+
+      publicVersion1.version shouldBe 1
+      publicVersion1.s3Bucket shouldBe S3Bucket(oldPublishBucket)
+
+      // "Complete" the publish job, then unpublish
+      publishSuccessfully(publicDataset, publicVersion1)
+
+      client
+        .unpublish(
+          organizationId,
+          datasetId,
+          defaultBucketUnpublishBody,
+          authToken
+        )
+        .awaitFinite()
+        .value
+        .asInstanceOf[UnpublishResponse.OK]
+        .value
+        .status shouldBe Unpublished
+
+      // republish with a DIFFERENT (org's current) bucket config
+      val newPublishBucket = s"new-publish-bucket-${organizationId}"
+      val newEmbargoBucket = s"new-embargo-bucket-${organizationId}"
+      val newBucketConfig = definitions.BucketConfig(
+        publish = newPublishBucket,
+        embargo = newEmbargoBucket
+      )
+
+      val requestBody2: definitions.PublishRequest =
+        requestBody1.copy(bucketConfig = Some(newBucketConfig))
+
+      val _ = client
+        .publish(organizationId, datasetId, None, None, requestBody2, authToken)
+        .awaitFinite()
+        .value
+        .asInstanceOf[PublishResponse.Created]
+        .value
+
+      val publicVersion2 = ports.db
+        .run(
+          PublicDatasetVersionsMapper
+            .getLatestVersion(publicDataset.id)
+        )
+        .awaitFinite()
+        .get
+
+      // The new version must land in the NEW bucket, not stay pinned to the
+      // unpublished version's old bucket.
+      publicVersion2.version shouldBe 2
+      publicVersion2.s3Bucket shouldBe S3Bucket(newPublishBucket)
+    }
+
   }
 
 }


### PR DESCRIPTION
After unpublishing then re-publishing, the current flow kept the previously used bucket

This means that if the custom storage bucket changes, then future publications still go to a old bucket